### PR TITLE
Refresh BitLoops workspace styling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+node_modules/
+bitloops_app/node_modules/
+dist/
+bitloops_app/dist/
+.coverage/
+bitloops_app/coverage/
+bitloops_app/.svelte-kit/
+.DS_Store
+*.log

--- a/bitloops_app/.npmrc
+++ b/bitloops_app/.npmrc
@@ -1,0 +1,2 @@
+registry=https://registry.npmjs.org/
+strict-ssl=true

--- a/bitloops_app/jsconfig.json
+++ b/bitloops_app/jsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "$components/*": ["src/components/*"],
+      "$lib/*": ["src/lib/*"],
+      "$store/*": ["src/store/*"],
+      "$src/*": ["src/*"]
+    }
+  },
+  "include": ["src/**/*", "vite.config.js", "svelte.config.js"]
+}

--- a/bitloops_app/package.json
+++ b/bitloops_app/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "bitloops_app",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "check": "svelte-check",
+    "test": "vitest",
+    "test:run": "vitest run",
+    "coverage": "vitest run --coverage"
+  },
+  "dependencies": {
+    "svelte": "^4.2.0"
+  },
+  "devDependencies": {
+    "@sveltejs/vite-plugin-svelte": "^3.0.0",
+    "@testing-library/svelte": "^4.2.2",
+    "@testing-library/user-event": "^14.5.2",
+    "@vitest/coverage-v8": "^1.2.0",
+    "@vitest/ui": "^1.2.0",
+    "jsdom": "^24.0.0",
+    "svelte-check": "^3.6.0",
+    "vite": "^5.0.0",
+    "vitest": "^1.2.0"
+  }
+}

--- a/bitloops_app/src/App.svelte
+++ b/bitloops_app/src/App.svelte
@@ -1,52 +1,535 @@
 <script>
+  import { onDestroy, onMount } from 'svelte';
+  import { get } from 'svelte/store';
   import Grid from './components/Grid.svelte';
   import TrackBar from './components/TrackBar.svelte';
   import Transport from './components/Transport.svelte';
   import Footer from './components/Footer.svelte';
-  import { project } from './store/projectStore.js';
+  import { Scheduler } from './lib/scheduler.js';
+  import { project, totalSteps, loopDuration, maxBars } from './store/projectStore.js';
+  import { scales } from './lib/scales.js';
+  import { colors } from './lib/colorTokens.js';
 
-  // Temporary local state for demonstration
-  let selectedTrack = 0;
-  let tracks = [
-    { name: 'Track 1', color: '#78D2B9' },
-    { name: 'Track 2', color: '#A88EF6' }
+  let $project;
+  let $totalSteps;
+  let $loopDuration;
+  let $maxBars;
+
+  const unsubscribers = [
+    project.subscribe((value) => ($project = value)),
+    totalSteps.subscribe((value) => ($totalSteps = value)),
+    loopDuration.subscribe((value) => ($loopDuration = value)),
+    maxBars.subscribe((value) => ($maxBars = value))
   ];
-  let playing = false;
-  let follow = false;
-  let activeNotes = Array(8).fill().map(() => Array(16).fill(false));
 
-  const handleToggle = (event) => {
-    const { row, col } = event.detail;
-    activeNotes[row][col] = !activeNotes[row][col];
+  let audioContext;
+  let scheduler;
+  let masterGain;
+  let animationId;
+
+  const ensureAudio = async () => {
+    if (typeof window === 'undefined') return false;
+    if (!audioContext) {
+      const AudioCtx = window.AudioContext || window.webkitAudioContext;
+      audioContext = AudioCtx ? new AudioCtx() : null;
+      if (!audioContext) return false;
+      masterGain = audioContext.createGain();
+      masterGain.gain.setValueAtTime(0.8, audioContext.currentTime);
+      masterGain.connect(audioContext.destination);
+    }
+    await audioContext.resume();
+    if (!scheduler) {
+      scheduler = new Scheduler(audioContext, $project.bpm, $project.stepsPerBar / 4);
+      scheduler.onStep = handleStep;
+    } else {
+      scheduler.setTempo($project.bpm);
+      scheduler.setStepsPerBeat($project.stepsPerBar / 4);
+      scheduler.onStep = handleStep;
+    }
+    return true;
   };
-  const handleSelect = (event) => {
-    selectedTrack = event.detail.index;
+
+  const midiToFrequency = (midi) => 440 * Math.pow(2, (midi - 69) / 12);
+
+  const getMidiForCell = (track, row) => {
+    const scalePattern = scales[track.scale] ?? scales.major;
+    const degrees = scalePattern.length;
+    const rows = $project.rows;
+    const indexFromBottom = rows - 1 - row;
+    const octaveOffset = Math.floor(indexFromBottom / degrees);
+    const degree = scalePattern[indexFromBottom % degrees];
+    const octave = track.octave + octaveOffset;
+    const midi = 12 * (octave + 1) + degree; // C0 = MIDI 12
+    return Math.min(Math.max(midi, 21), 108);
   };
-  const handleTogglePlay = () => {
-    playing = !playing;
+
+  const playTone = (track, frequency, time, duration) => {
+    if (!audioContext || !masterGain || !Number.isFinite(frequency)) return;
+    const gainNode = audioContext.createGain();
+    gainNode.gain.setValueAtTime(0, time);
+    const attack = 0.01;
+    const release = Math.min(0.3, duration * 0.8);
+    const sustainTime = time + Math.max(attack, duration * 0.4);
+    const releaseStart = time + duration - release;
+    gainNode.gain.linearRampToValueAtTime(track.volume, time + attack);
+    gainNode.gain.setValueAtTime(track.volume, sustainTime);
+    gainNode.gain.linearRampToValueAtTime(0.0001, releaseStart + release);
+    gainNode.connect(masterGain);
+
+    if (track.waveform === 'noise') {
+      const buffer = audioContext.createBuffer(1, Math.floor(audioContext.sampleRate * (duration + 0.1)), audioContext.sampleRate);
+      const data = buffer.getChannelData(0);
+      for (let i = 0; i < data.length; i += 1) {
+        data[i] = Math.random() * 2 - 1;
+      }
+      const source = audioContext.createBufferSource();
+      source.buffer = buffer;
+      source.connect(gainNode);
+      source.start(time);
+      source.stop(releaseStart + release + 0.05);
+    } else {
+      const osc = audioContext.createOscillator();
+      osc.type = track.waveform;
+      osc.frequency.setValueAtTime(frequency, time);
+      osc.connect(gainNode);
+      osc.start(time);
+      osc.stop(releaseStart + release + 0.05);
+    }
   };
-  const handleToggleFollow = () => {
-    follow = !follow;
+
+  const scheduleAudio = (stepIndex, time, stepDuration, state) => {
+    const rows = state.rows;
+    const totalSteps = state.bars * state.stepsPerBar;
+    if (!totalSteps) return;
+    const audibleTracks = state.tracks.some((track) => track.solo)
+      ? state.tracks.filter((track) => track.solo)
+      : state.tracks.filter((track) => !track.mute);
+
+    audibleTracks.forEach((track) => {
+      for (let row = 0; row < rows; row += 1) {
+        if (track.notes?.[row]?.[stepIndex]) {
+          const midi = getMidiForCell(track, row);
+          const frequency = midiToFrequency(midi);
+          playTone(track, frequency, time, stepDuration * 0.95);
+        }
+      }
+    });
   };
+
+  const handleStep = (step, time, duration) => {
+    const state = get(project);
+    const totalSteps = state.bars * state.stepsPerBar;
+    if (!totalSteps) return;
+    const stepIndex = ((step % totalSteps) + totalSteps) % totalSteps;
+    project.registerStep(stepIndex, time, duration);
+    scheduleAudio(stepIndex, time, duration, state);
+  };
+
+  const animatePlayhead = () => {
+    if (!$project?.playing || !audioContext) return;
+    const state = get(project);
+    const delta = state.nextStepTime - state.lastStepTime;
+    if (delta > 0) {
+      const now = audioContext.currentTime;
+      const progress = (now - state.lastStepTime) / delta;
+      if (Number.isFinite(progress)) {
+        project.setPlayheadProgress(Math.min(Math.max(progress, 0), 1));
+      }
+    }
+    animationId = requestAnimationFrame(animatePlayhead);
+  };
+
+  const startPlayback = async () => {
+    if (!(await ensureAudio())) return;
+    project.resetPlayhead();
+    project.setPlaying(true);
+    scheduler.setTempo($project.bpm);
+    scheduler.setStepsPerBeat($project.stepsPerBar / 4);
+    scheduler.start();
+    if (animationId) cancelAnimationFrame(animationId);
+    animationId = requestAnimationFrame(animatePlayhead);
+  };
+
+  const stopPlayback = () => {
+    if (scheduler) {
+      scheduler.stop();
+    }
+    if (animationId) {
+      cancelAnimationFrame(animationId);
+      animationId = null;
+    }
+    project.setPlaying(false);
+    project.resetPlayhead();
+  };
+
+  const handleTogglePlay = async () => {
+    if ($project.playing) {
+      stopPlayback();
+    } else {
+      await startPlayback();
+    }
+  };
+
+  const handleFollowToggle = (event) => {
+    const nextValue = event.detail?.value ?? !$project.follow;
+    project.setFollow(nextValue);
+  };
+
+  const handleBpmChange = (event) => {
+    const value = Number(event.detail?.value ?? event.target?.value);
+    if (!Number.isNaN(value)) {
+      project.setBpm(value);
+      if (scheduler) {
+        scheduler.setTempo(get(project).bpm);
+      }
+    }
+  };
+
+  const handleNoteChange = (event) => {
+    const { row, step, value } = event.detail;
+    project.toggleNote($project.selectedTrack, row, step, value);
+  };
+
+  const handleTrackSelect = (event) => {
+    project.selectTrack(event.detail.index);
+  };
+
+  const handleTrackUpdate = (event) => {
+    const { index, key, value } = event.detail;
+    project.setTrackSetting(index, key, value);
+  };
+
+  const handleBarsChange = (event) => {
+    const value = Number(event.detail?.value ?? event.target?.value);
+    project.setBars(value);
+  };
+
+  const handleStepsChange = (event) => {
+    const value = Number(event.detail?.value ?? event.target?.value);
+    project.setStepsPerBar(value);
+    if (scheduler) {
+      scheduler.setStepsPerBeat(get(project).stepsPerBar / 4);
+    }
+  };
+
+  const handleExport = () => {
+    if (typeof window === 'undefined') return;
+    const data = project.serialize();
+    const json = JSON.stringify(data, null, 2);
+    const blob = new Blob([json], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = 'bitloops-project.json';
+    document.body.appendChild(anchor);
+    anchor.click();
+    document.body.removeChild(anchor);
+    URL.revokeObjectURL(url);
+  };
+
+  const handleImport = (event) => {
+    const json = event.detail?.json;
+    if (!json) return;
+    try {
+      const payload = JSON.parse(json);
+      const success = project.load(payload);
+      if (success) {
+        stopPlayback();
+        if (scheduler) {
+          scheduler.setTempo(get(project).bpm);
+          scheduler.setStepsPerBeat(get(project).stepsPerBar / 4);
+        }
+      }
+    } catch (error) {
+      console.error('Failed to import project', error);
+      // eslint-disable-next-line no-alert
+      alert('Unable to import project file. Please ensure it is a valid BitLoops JSON export.');
+    }
+  };
+
+  onMount(() => {
+    return () => {
+      stopPlayback();
+      if (audioContext) {
+        audioContext.close?.();
+      }
+    };
+  });
+
+  onDestroy(() => {
+    unsubscribers.forEach((unsubscribe) => unsubscribe?.());
+  });
+
+  $: activeTrack = $project.tracks?.[$project.selectedTrack];
+  $: columns = $totalSteps;
+  $: rows = $project.rows;
+  $: gridNotes = activeTrack?.notes ?? [];
+  $: trackColor = activeTrack?.color ?? colors.accent;
 </script>
 
-<main class="min-h-screen bg-bg text-white flex flex-col">
-  <div class="flex-1 flex">
-    <!-- Transport rail -->
-    <Transport {playing} {follow}
-      on:toggleplay={handleTogglePlay}
-      on:togglefollow={handleToggleFollow}
-    />
-    <div class="flex flex-col flex-1">
-      <TrackBar {tracks} selected={selectedTrack} on:select={handleSelect} />
-      <div class="flex-1 p-4">
-        <Grid rows={8} columns={16} {activeNotes} on:toggle={handleToggle} />
+<main class="app">
+  <aside class="app-rail">
+    <div class="rail-inner">
+      <div class="brand">
+        <span class="brand-mark">BitLoops</span>
+        <p class="brand-tag">Dot grid sequencer</p>
       </div>
-      <Footer bars={4} stepsPerBar={16} bpm={120} />
+      <Transport
+        playing={$project.playing}
+        follow={$project.follow}
+        bpm={$project.bpm}
+        on:toggleplay={handleTogglePlay}
+        on:togglefollow={handleFollowToggle}
+        on:changebpm={handleBpmChange}
+      />
+      <div class="rail-stats">
+        <div>
+          <span class="label">Loop length</span>
+          <span class="value">{$loopDuration.toFixed(1)}s</span>
+        </div>
+        <div>
+          <span class="label">Bars</span>
+          <span class="value">{$project.bars}</span>
+        </div>
+        <div>
+          <span class="label">Steps / bar</span>
+          <span class="value">{$project.stepsPerBar}</span>
+        </div>
+      </div>
     </div>
-  </div>
+  </aside>
+  <section class="workspace">
+    <div class="workspace-header">
+      <div class="session-info">
+        <span class="eyebrow">Active track</span>
+        <h1>{activeTrack?.name ?? 'Untitled track'}</h1>
+        <p class="session-meta">
+          {activeTrack
+            ? `${activeTrack.scale} scale • octave ${activeTrack.octave} • ${Math.round(activeTrack.volume * 100)}% vol`
+            : 'Select a track to edit settings'}
+        </p>
+      </div>
+      <div class="status-pills">
+        <span class={`pill ${$project.playing ? 'playing' : ''}`}>
+          {$project.playing ? 'Playing' : 'Stopped'}
+        </span>
+        <span class={`pill ${$project.follow ? 'following' : ''}`}>
+          {$project.follow ? 'Follow on' : 'Follow off'}
+        </span>
+      </div>
+    </div>
+    <TrackBar
+      tracks={$project.tracks}
+      selected={$project.selectedTrack}
+      on:select={handleTrackSelect}
+      on:update={handleTrackUpdate}
+    />
+    <div class="grid-shell">
+      <div class="grid-backdrop">
+        <Grid
+          {rows}
+          {columns}
+          notes={gridNotes}
+          playheadStep={$project.playheadStep}
+          playheadProgress={$project.playheadProgress}
+          trackColor={trackColor}
+          follow={$project.follow}
+          isPlaying={$project.playing}
+          stepsPerBar={$project.stepsPerBar}
+          on:notechange={handleNoteChange}
+        />
+      </div>
+    </div>
+    <Footer
+      bars={$project.bars}
+      stepsPerBar={$project.stepsPerBar}
+      bpm={$project.bpm}
+      loopSeconds={$loopDuration}
+      maxBars={$maxBars}
+      on:changebars={handleBarsChange}
+      on:changesteps={handleStepsChange}
+      on:export={handleExport}
+      on:import={handleImport}
+    />
+  </section>
 </main>
 
 <style>
-  main { background-color: var(--bg); }
+  :global(:root) {
+    --accent: #78d2b9;
+    --note-active: #78d2ff;
+    --note-inactive: #3c4450;
+    --bg: #0e1016;
+    --panel: #161a24;
+    --playhead: rgba(120, 210, 185, 0.85);
+    --grid-line: rgba(255, 255, 255, 0.08);
+  }
+
+  :global(body) {
+    margin: 0;
+    font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    background: radial-gradient(circle at top left, rgba(120, 210, 185, 0.22), transparent 45%),
+      radial-gradient(circle at bottom right, rgba(120, 210, 255, 0.18), transparent 40%), var(--bg);
+    color: #fff;
+    min-height: 100vh;
+  }
+
+  .app {
+    min-height: 100vh;
+    display: grid;
+    grid-template-columns: 280px 1fr;
+    backdrop-filter: blur(0px);
+    color: #fff;
+  }
+
+  .app-rail {
+    background: linear-gradient(180deg, rgba(22, 26, 36, 0.95) 0%, rgba(14, 16, 22, 0.98) 100%);
+    border-right: 1px solid rgba(255, 255, 255, 0.05);
+    display: flex;
+    justify-content: center;
+    padding: 32px 28px;
+  }
+
+  .rail-inner {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: 32px;
+  }
+
+  .brand {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .brand-mark {
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    font-size: 1rem;
+  }
+
+  .brand-tag {
+    margin: 0;
+    font-size: 0.85rem;
+    color: rgba(255, 255, 255, 0.6);
+  }
+
+  .rail-stats {
+    margin-top: auto;
+    display: grid;
+    gap: 16px;
+    padding: 18px;
+    border-radius: 16px;
+    background: linear-gradient(145deg, rgba(120, 210, 185, 0.12), rgba(22, 26, 36, 0.6));
+    border: 1px solid rgba(120, 210, 185, 0.24);
+  }
+
+  .rail-stats .label {
+    display: block;
+    font-size: 0.7rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: rgba(255, 255, 255, 0.55);
+  }
+
+  .rail-stats .value {
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: #fff;
+  }
+
+  .workspace {
+    display: flex;
+    flex-direction: column;
+    backdrop-filter: blur(20px);
+    background: rgba(14, 16, 22, 0.72);
+  }
+
+  .workspace-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 28px 32px 16px;
+    gap: 24px;
+  }
+
+  .session-info {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .eyebrow {
+    text-transform: uppercase;
+    letter-spacing: 0.14em;
+    font-size: 0.75rem;
+    color: rgba(255, 255, 255, 0.48);
+  }
+
+  .session-info h1 {
+    margin: 0;
+    font-size: 1.8rem;
+    letter-spacing: 0.04em;
+  }
+
+  .session-meta {
+    margin: 0;
+    color: rgba(255, 255, 255, 0.6);
+    font-size: 0.95rem;
+  }
+
+  .status-pills {
+    display: flex;
+    gap: 12px;
+    flex-wrap: wrap;
+  }
+
+  .pill {
+    padding: 8px 14px;
+    border-radius: 999px;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    background: rgba(255, 255, 255, 0.04);
+    font-size: 0.8rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: rgba(255, 255, 255, 0.7);
+  }
+
+  .pill.playing,
+  .pill.following {
+    border-color: rgba(120, 210, 185, 0.5);
+    color: #fff;
+  }
+
+  .grid-shell {
+    flex: 1;
+    padding: 0 32px 32px;
+  }
+
+  .grid-backdrop {
+    position: relative;
+    height: 100%;
+    border-radius: 24px;
+    padding: 20px;
+    background: linear-gradient(135deg, rgba(22, 26, 36, 0.92), rgba(12, 14, 20, 0.88));
+    border: 1px solid rgba(120, 210, 255, 0.08);
+    box-shadow: 0 30px 80px rgba(12, 14, 20, 0.6);
+  }
+
+  .grid-backdrop :global(.grid-wrapper) {
+    height: 100%;
+  }
+
+  @media (max-width: 960px) {
+    .app {
+      grid-template-columns: 1fr;
+    }
+
+    .app-rail {
+      border-right: none;
+      border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+    }
+  }
 </style>

--- a/bitloops_app/src/__tests__/Grid.spec.js
+++ b/bitloops_app/src/__tests__/Grid.spec.js
@@ -1,0 +1,42 @@
+import { render, fireEvent } from '@testing-library/svelte';
+import { describe, it, expect, vi } from 'vitest';
+import Grid from '../components/Grid.svelte';
+
+const createNotes = (rows, cols) =>
+  Array.from({ length: rows }, () => Array.from({ length: cols }, () => false));
+
+describe('Grid component', () => {
+  it('dispatches notechange on pointer interactions', async () => {
+    const rows = 4;
+    const columns = 8;
+    const { component, container } = render(Grid, {
+      props: {
+        rows,
+        columns,
+        notes: createNotes(rows, columns),
+        playheadStep: 0,
+        playheadProgress: 0,
+        follow: false,
+        isPlaying: false
+      }
+    });
+
+    const noteChange = vi.fn();
+    component.$on('notechange', noteChange);
+
+    const canvas = container.querySelector('canvas');
+    canvas.getBoundingClientRect = () => ({ left: 0, top: 0, width: 320, height: 160 });
+    canvas.setPointerCapture = vi.fn();
+    canvas.releasePointerCapture = vi.fn();
+
+    await fireEvent.pointerDown(canvas, { clientX: 10, clientY: 10, pointerId: 1 });
+    await fireEvent.pointerMove(canvas, { clientX: 70, clientY: 10, pointerId: 1 });
+    await fireEvent.pointerUp(canvas, { pointerId: 1 });
+
+    expect(noteChange).toHaveBeenCalled();
+    const event = noteChange.mock.calls[0][0];
+    expect(event.detail).toHaveProperty('row');
+    expect(event.detail).toHaveProperty('step');
+    expect(event.detail).toHaveProperty('value');
+  });
+});

--- a/bitloops_app/src/components/Footer.svelte
+++ b/bitloops_app/src/components/Footer.svelte
@@ -1,18 +1,211 @@
 <script>
+  import { createEventDispatcher } from 'svelte';
+
   export let bars = 4;
   export let stepsPerBar = 16;
   export let bpm = 120;
-  /** Calculate loop length in seconds */
-  $: loopSeconds = (60 / bpm) * (stepsPerBar / 4) * bars;
+  export let loopSeconds = 0;
+  export let maxBars = 64;
+
+  const dispatch = createEventDispatcher();
+  let fileInput;
+
+  const handleBarsChange = (event) => {
+    const value = Number(event.target.value);
+    dispatch('changebars', { value });
+  };
+
+  const handleStepsChange = (event) => {
+    const value = Number(event.target.value);
+    dispatch('changesteps', { value });
+  };
+
+  const handleExport = () => {
+    dispatch('export');
+  };
+
+  const handleImportClick = () => {
+    fileInput?.click();
+  };
+
+  const handleImport = async (event) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    try {
+      const text = await file.text();
+      dispatch('import', { json: text });
+    } finally {
+      event.target.value = '';
+    }
+  };
 </script>
 
-<div class="flex justify-between p-2 text-xs bg-panel">
-  <span>{bars} bars</span>
-  <span>{stepsPerBar} steps/bar</span>
-  <span>{bpm} BPM</span>
-  <span>{loopSeconds.toFixed(1)} s</span>
-</div>
+<footer class="footer">
+  <div class="timing">
+    <div class="field">
+      <label for="bars">Bars</label>
+      <div class="input-shell">
+        <input
+          id="bars"
+          type="number"
+          min="1"
+          max={maxBars}
+          value={bars}
+          on:change={handleBarsChange}
+        />
+        <span class="hint">Max {maxBars}</span>
+      </div>
+    </div>
+    <div class="field">
+      <label for="steps">Steps / bar</label>
+      <div class="input-shell">
+        <input
+          id="steps"
+          type="number"
+          min="4"
+          max="64"
+          step="1"
+          value={stepsPerBar}
+          on:change={handleStepsChange}
+        />
+      </div>
+    </div>
+    <div class="loop-card">
+      <span class="loop-label">Loop</span>
+      <span class="loop-value">{loopSeconds.toFixed(1)} s</span>
+      <span class="loop-sub">{bpm} BPM</span>
+    </div>
+  </div>
+  <div class="actions">
+    <button class="ghost" type="button" on:click={handleExport}>Export project</button>
+    <button class="primary" type="button" on:click={handleImportClick}>Import</button>
+    <input type="file" accept=".json,.bitloops.json" bind:this={fileInput} on:change={handleImport} hidden />
+  </div>
+</footer>
 
 <style>
-  .bg-panel { background-color: var(--panel); color: var(--accent); }
+  .footer {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 20px 32px 28px;
+    gap: 24px;
+    flex-wrap: wrap;
+    color: rgba(255, 255, 255, 0.85);
+  }
+
+  .timing {
+    display: flex;
+    align-items: center;
+    gap: 24px;
+    flex-wrap: wrap;
+  }
+
+  .field {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+  }
+
+  .field label {
+    color: rgba(255, 255, 255, 0.58);
+  }
+
+  .input-shell {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 14px;
+    border-radius: 12px;
+    background: rgba(0, 0, 0, 0.4);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+  }
+
+  .input-shell input {
+    width: 72px;
+    background: transparent;
+    border: none;
+    color: #fff;
+    font-size: 0.95rem;
+    font-weight: 600;
+    appearance: textfield;
+    outline: none;
+  }
+
+  .input-shell input::-webkit-outer-spin-button,
+  .input-shell input::-webkit-inner-spin-button {
+    appearance: none;
+    margin: 0;
+  }
+
+  .hint {
+    font-size: 0.7rem;
+    color: rgba(255, 255, 255, 0.45);
+    letter-spacing: 0.08em;
+  }
+
+  .loop-card {
+    display: grid;
+    gap: 4px;
+    padding: 16px 18px;
+    border-radius: 16px;
+    background: linear-gradient(135deg, rgba(120, 210, 255, 0.18), rgba(14, 16, 22, 0.9));
+    border: 1px solid rgba(120, 210, 255, 0.25);
+    min-width: 150px;
+  }
+
+  .loop-label {
+    text-transform: uppercase;
+    font-size: 0.72rem;
+    letter-spacing: 0.1em;
+    color: rgba(255, 255, 255, 0.55);
+  }
+
+  .loop-value {
+    font-size: 1.4rem;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+  }
+
+  .loop-sub {
+    font-size: 0.78rem;
+    color: rgba(255, 255, 255, 0.55);
+    letter-spacing: 0.12em;
+  }
+
+  .actions {
+    display: flex;
+    gap: 12px;
+    flex-wrap: wrap;
+  }
+
+  .actions button {
+    padding: 12px 18px;
+    border-radius: 14px;
+    font-size: 0.85rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+  }
+
+  .actions button:hover {
+    transform: translateY(-2px);
+  }
+
+  .ghost {
+    border: 1px solid rgba(255, 255, 255, 0.25);
+    background: rgba(255, 255, 255, 0.05);
+    color: #fff;
+  }
+
+  .primary {
+    border: 1px solid rgba(120, 210, 185, 0.6);
+    background: rgba(120, 210, 185, 0.22);
+    color: #fff;
+    box-shadow: 0 16px 40px rgba(120, 210, 185, 0.3);
+  }
 </style>

--- a/bitloops_app/src/components/Grid.svelte
+++ b/bitloops_app/src/components/Grid.svelte
@@ -1,39 +1,275 @@
 <script>
-  // Props: activeNotes is a 2D boolean array
-  export let activeNotes = [];
+  import { createEventDispatcher, onDestroy, onMount } from 'svelte';
+
+  export let notes = [];
   export let rows = 8;
-  export let columns = 16;
-  /**
-   * Emit an event when a note is toggled
-   * @param {number} row
-   * @param {number} col
-   */
-  const toggleNote = (row, col) => {
-    const event = new CustomEvent('toggle', { detail: { row, col } });
-    dispatchEvent(event);
+export let columns = 16;
+export let stepsPerBar = 16;
+  export let playheadStep = 0;
+  export let playheadProgress = 0;
+  export let trackColor = '#78D2B9';
+  export let follow = true;
+  export let isPlaying = false;
+
+  const dispatch = createEventDispatcher();
+
+  let canvas;
+  let scroller;
+  let ctx;
+  let layout = { cellSize: 32, width: 0, height: 0, dpr: 1 };
+  let pointerActive = false;
+  let paintValue = true;
+  let paintedCells = new Set();
+  let resizeObserver;
+
+  const hexToRgba = (hex, alpha = 1) => {
+    if (!hex) return `rgba(120, 210, 185, ${alpha})`;
+    const clean = hex.replace('#', '');
+    const bigint = parseInt(clean.length === 3 ? clean.replace(/(.)/g, '$1$1') : clean, 16);
+    const r = (bigint >> 16) & 255;
+    const g = (bigint >> 8) & 255;
+    const b = bigint & 255;
+    return `rgba(${r}, ${g}, ${b}, ${alpha})`;
   };
+
+  const getStyles = () => {
+    const style = getComputedStyle(canvas);
+    return {
+      background: style.getPropertyValue('--panel')?.trim() || '#161A24',
+      grid: style.getPropertyValue('--grid-line')?.trim() || 'rgba(255,255,255,0.08)',
+      inactive: style.getPropertyValue('--note-inactive')?.trim() || '#3C4450',
+      playhead: style.getPropertyValue('--playhead')?.trim() || hexToRgba(trackColor, 0.9)
+    };
+  };
+
+  const updateLayout = () => {
+    if (!canvas || !scroller) return;
+    const dpr = typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1;
+    const visibleColumns = Math.min(columns, 16);
+    const availableWidth = scroller.clientWidth || columns * 32;
+    const cellSize = Math.max(18, Math.min(48, Math.floor(availableWidth / visibleColumns)));
+    const width = Math.max(columns * cellSize, availableWidth);
+    const height = rows * cellSize;
+
+    layout = { cellSize, width, height, dpr };
+
+    canvas.width = width * dpr;
+    canvas.height = height * dpr;
+    canvas.style.width = `${width}px`;
+    canvas.style.height = `${height}px`;
+
+    if (!ctx) {
+      ctx = canvas.getContext('2d');
+    }
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    draw();
+  };
+
+  const draw = () => {
+    if (!ctx) return;
+    const styles = getStyles();
+    ctx.clearRect(0, 0, layout.width, layout.height);
+    const backgroundGradient = ctx.createLinearGradient(0, 0, 0, layout.height);
+    backgroundGradient.addColorStop(0, styles.background);
+    backgroundGradient.addColorStop(1, 'rgba(14, 16, 22, 0.92)');
+    ctx.fillStyle = backgroundGradient;
+    ctx.fillRect(0, 0, layout.width, layout.height);
+
+    const barWidth = Math.max(stepsPerBar, 1) * layout.cellSize;
+    ctx.save();
+    ctx.globalCompositeOperation = 'lighter';
+    for (let col = 0; col < columns; col += stepsPerBar) {
+      const x = col * layout.cellSize;
+      const stripe = ctx.createLinearGradient(x, 0, x + layout.cellSize * 1.5, 0);
+      stripe.addColorStop(0, hexToRgba(trackColor, 0.08));
+      stripe.addColorStop(1, 'transparent');
+      ctx.fillStyle = stripe;
+      ctx.fillRect(x, 0, layout.cellSize * 1.5, layout.height);
+
+      const wash = ctx.createLinearGradient(x, 0, x + barWidth, 0);
+      wash.addColorStop(0, hexToRgba(trackColor, 0.04));
+      wash.addColorStop(1, 'transparent');
+      ctx.fillStyle = wash;
+      ctx.fillRect(x, 0, barWidth, layout.height);
+    }
+    ctx.restore();
+
+    const radius = layout.cellSize * 0.28;
+
+    for (let row = 0; row < rows; row += 1) {
+      for (let col = 0; col < columns; col += 1) {
+        const active = notes?.[row]?.[col];
+        const cx = col * layout.cellSize + layout.cellSize / 2;
+        const cy = row * layout.cellSize + layout.cellSize / 2;
+        ctx.beginPath();
+        const inactive = ctx.createRadialGradient(cx, cy, radius * 0.1, cx, cy, radius);
+        inactive.addColorStop(0, 'rgba(255, 255, 255, 0.25)');
+        inactive.addColorStop(1, styles.inactive);
+        if (active) {
+          ctx.shadowColor = hexToRgba(trackColor, 0.7);
+          ctx.shadowBlur = layout.cellSize * 0.5;
+          ctx.fillStyle = hexToRgba(trackColor, 0.9);
+        } else {
+          ctx.shadowColor = 'transparent';
+          ctx.shadowBlur = 0;
+          ctx.fillStyle = inactive;
+        }
+        ctx.arc(cx, cy, radius, 0, Math.PI * 2);
+        ctx.fill();
+        if (active) {
+          ctx.beginPath();
+          ctx.fillStyle = hexToRgba(trackColor, 0.45);
+          ctx.arc(cx, cy, radius * 0.55, 0, Math.PI * 2);
+          ctx.fill();
+        }
+      }
+    }
+
+    const playheadX = (playheadStep + playheadProgress) * layout.cellSize;
+    ctx.shadowColor = 'transparent';
+    ctx.shadowBlur = 0;
+    const playheadGlow = ctx.createLinearGradient(playheadX - layout.cellSize, 0, playheadX + layout.cellSize, 0);
+    playheadGlow.addColorStop(0, 'transparent');
+    playheadGlow.addColorStop(0.5, hexToRgba(trackColor, 0.2));
+    playheadGlow.addColorStop(1, 'transparent');
+    ctx.fillStyle = playheadGlow;
+    ctx.fillRect(playheadX - layout.cellSize, 0, layout.cellSize * 2, layout.height);
+    ctx.strokeStyle = styles.playhead;
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    ctx.moveTo(playheadX, 0);
+    ctx.lineTo(playheadX, layout.height);
+    ctx.stroke();
+  };
+
+  const getCellFromEvent = (event) => {
+    const rect = canvas.getBoundingClientRect();
+    const x = event.clientX - rect.left;
+    const y = event.clientY - rect.top;
+    const col = Math.floor(x / layout.cellSize);
+    const row = Math.floor(y / layout.cellSize);
+    if (row < 0 || row >= rows || col < 0 || col >= columns) {
+      return null;
+    }
+    return { row, col };
+  };
+
+  const emitNoteChange = (row, col, value) => {
+    dispatch('notechange', { row, step: col, value });
+  };
+
+  const handlePointer = (event) => {
+    if (!pointerActive && event.type === 'pointermove') return;
+    const cell = getCellFromEvent(event);
+    if (!cell) return;
+    const key = `${cell.row}:${cell.col}`;
+    if (paintedCells.has(key)) return;
+    paintedCells.add(key);
+    if (!pointerActive) {
+      pointerActive = true;
+      paintValue = !(notes?.[cell.row]?.[cell.col]);
+    }
+    emitNoteChange(cell.row, cell.col, paintValue);
+  };
+
+  const handlePointerDown = (event) => {
+    event.preventDefault();
+    canvas.setPointerCapture(event.pointerId);
+    pointerActive = false;
+    paintedCells = new Set();
+    handlePointer(event);
+  };
+
+  const handlePointerMove = (event) => {
+    if (!pointerActive) return;
+    handlePointer(event);
+  };
+
+  const releasePointer = (event) => {
+    if (canvas) {
+      try {
+        canvas.releasePointerCapture(event.pointerId);
+      } catch (e) {
+        // Ignore if capture was not set.
+      }
+    }
+    pointerActive = false;
+    paintedCells = new Set();
+  };
+
+  const handlePointerUp = (event) => {
+    releasePointer(event);
+  };
+
+  const handlePointerCancel = (event) => {
+    releasePointer(event);
+  };
+
+  onMount(() => {
+    if (!canvas) return;
+    ctx = canvas.getContext('2d');
+    updateLayout();
+    if (typeof ResizeObserver !== 'undefined') {
+      resizeObserver = new ResizeObserver(() => updateLayout());
+      if (scroller) resizeObserver.observe(scroller);
+    }
+    const handleWindowResize = () => updateLayout();
+    window.addEventListener('resize', handleWindowResize);
+    return () => {
+      window.removeEventListener('resize', handleWindowResize);
+    };
+  });
+
+  onDestroy(() => {
+    if (resizeObserver && scroller) {
+      resizeObserver.unobserve(scroller);
+      resizeObserver.disconnect();
+    }
+  });
+
+  $: if (canvas && scroller && ctx && columns && rows) {
+    updateLayout();
+  }
+
+  $: draw();
+
+  $: if (follow && isPlaying && scroller) {
+    const playheadX = (playheadStep + playheadProgress) * layout.cellSize;
+    const center = playheadX - scroller.clientWidth / 2;
+    const target = Math.max(0, center);
+    if (Math.abs(scroller.scrollLeft - target) > 2) {
+      scroller.scrollTo({ left: target, behavior: 'smooth' });
+    }
+  }
 </script>
 
-<!--
-  This component will eventually render a canvas and handle hit testing.
-  For the stub, we show a simple grid of buttons.
--->
-<div class="grid" style="display: grid; grid-template-columns: repeat({columns}, 1fr); gap: 2px;">
-  {#each Array(rows) as _, row}
-    {#each Array(columns) as __, col}
-      <button
-        class="w-4 h-4 rounded-full border-0 focus:outline-none {activeNotes[row] && activeNotes[row][col] ? 'bg-accent' : 'bg-noteInactive'}"
-        on:click={() => toggleNote(row, col)}
-      ></button>
-    {/each}
-  {/each}
+<div class="grid-wrapper" bind:this={scroller}>
+  <canvas
+    class="grid-canvas"
+    bind:this={canvas}
+    on:pointerdown={handlePointerDown}
+    on:pointermove={handlePointerMove}
+    on:pointerup={handlePointerUp}
+    on:pointerleave={handlePointerCancel}
+    on:pointercancel={handlePointerCancel}
+  ></canvas>
 </div>
 
 <style>
-  .bg-accent {
-    background-color: var(--accent);
+  .grid-wrapper {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    overflow-x: auto;
+    overflow-y: hidden;
+    background: var(--panel);
+    border-radius: 12px;
+    border: 1px solid rgba(255, 255, 255, 0.05);
   }
-  .bg-noteInactive {
-    background-color: var(--note-inactive);
+
+  .grid-canvas {
+    touch-action: none;
+    cursor: crosshair;
+    display: block;
   }
 </style>

--- a/bitloops_app/src/components/TrackBar.svelte
+++ b/bitloops_app/src/components/TrackBar.svelte
@@ -1,29 +1,297 @@
 <script>
+  import { createEventDispatcher } from 'svelte';
+  import { scales } from '../lib/scales.js';
+
   export let tracks = [];
   export let selected = 0;
-  /**
-   * Select a track by index
-   * @param {number} idx
-   */
-  const selectTrack = (idx) => {
-    const event = new CustomEvent('select', { detail: { index: idx } });
-    dispatchEvent(event);
+
+  const dispatch = createEventDispatcher();
+
+  const waveformOptions = ['sine', 'square', 'triangle', 'sawtooth', 'noise'];
+  const scaleOptions = Object.keys(scales);
+
+  const handleSelect = (idx) => {
+    dispatch('select', { index: idx });
+  };
+
+  const handleChange = (key, value) => {
+    dispatch('update', { index: selected, key, value });
+  };
+
+  const toggleBoolean = (key, current) => {
+    dispatch('update', { index: selected, key, value: !current });
   };
 </script>
 
-<div class="flex space-x-2 p-2 bg-panel">
-  {#each tracks as track, idx}
-    <div
-      class="flex items-center cursor-pointer px-3 py-1 rounded shadow-sm {idx === selected ? 'bg-accent' : 'bg-panel'}"
-      on:click={() => selectTrack(idx)}
-    >
-      <div class="w-2 h-4 mr-2 rounded" style="background-color: {track.color || 'var(--accent)'}"></div>
-      <span class="text-sm">{track.name}</span>
+<div class="trackbar">
+  <div class="track-list" role="tablist" aria-label="Tracks">
+    {#each tracks as track, idx}
+      <button
+        class="track-chip {idx === selected ? 'selected' : ''}"
+        on:click={() => handleSelect(idx)}
+        type="button"
+        role="tab"
+        aria-selected={idx === selected}
+      >
+        <span class="chip-strip" style={`background:${track.color}`}></span>
+        <span class="chip-content">
+          <span class="chip-name">{track.name}</span>
+          <span class="chip-meta">{track.waveform} • {track.scale}</span>
+        </span>
+      </button>
+    {/each}
+  </div>
+
+  {#if tracks && tracks[selected]}
+    <div class="control-panel">
+      <div class="control">
+        <label for="waveform">Waveform</label>
+        <select
+          id="waveform"
+          on:change={(event) => handleChange('waveform', event.target.value)}
+          value={tracks[selected].waveform}
+        >
+          {#each waveformOptions as option}
+            <option value={option}>{option}</option>
+          {/each}
+        </select>
+      </div>
+
+      <div class="control">
+        <label for="scale">Scale</label>
+        <select
+          id="scale"
+          on:change={(event) => handleChange('scale', event.target.value)}
+          value={tracks[selected].scale}
+        >
+          {#each scaleOptions as option}
+            <option value={option}>{option}</option>
+          {/each}
+        </select>
+      </div>
+
+      <div class="control">
+        <label for="octave">Octave</label>
+        <div class="number-field">
+          <input
+            id="octave"
+            type="number"
+            min="1"
+            max="7"
+            value={tracks[selected].octave}
+            on:change={(event) => handleChange('octave', Number(event.target.value))}
+          />
+        </div>
+      </div>
+
+      <div class="control volume">
+        <label for="volume">Volume</label>
+        <input
+          id="volume"
+          type="range"
+          min="0"
+          max="1"
+          step="0.01"
+          value={tracks[selected].volume}
+          on:input={(event) => handleChange('volume', Number(event.target.value))}
+        />
+        <span class="volume-value">{Math.round(tracks[selected].volume * 100)}%</span>
+      </div>
+
+      <div class="control toggles">
+        <button
+          type="button"
+          class:active={tracks[selected].mute}
+          on:click={() => toggleBoolean('mute', tracks[selected].mute)}
+        >
+          {tracks[selected].mute ? 'Muted' : 'Mute'}
+        </button>
+        <button
+          type="button"
+          class:active={tracks[selected].solo}
+          on:click={() => toggleBoolean('solo', tracks[selected].solo)}
+        >
+          {tracks[selected].solo ? 'Soloing' : 'Solo'}
+        </button>
+      </div>
     </div>
-  {/each}
+  {/if}
 </div>
 
 <style>
-  .bg-panel { background-color: var(--panel); }
-  .bg-accent { background-color: var(--accent); color: #0e1016; }
-</style>
+  .trackbar {
+    display: flex;
+    flex-direction: column;
+    padding: 24px 32px 16px;
+    gap: 18px;
+  }
+
+  .track-list {
+    display: grid;
+    grid-auto-flow: column;
+    grid-auto-columns: minmax(210px, 1fr);
+    gap: 16px;
+    overflow-x: auto;
+    padding-bottom: 6px;
+    scrollbar-width: thin;
+  }
+
+  .track-list::-webkit-scrollbar {
+    height: 6px;
+  }
+
+  .track-list::-webkit-scrollbar-thumb {
+    background: rgba(120, 210, 185, 0.3);
+    border-radius: 999px;
+  }
+
+  .track-chip {
+    display: grid;
+    grid-template-columns: 12px 1fr;
+    align-items: center;
+    padding: 12px 16px;
+    border-radius: 16px;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    background: rgba(17, 20, 29, 0.85);
+    color: #fff;
+    text-align: left;
+    gap: 14px;
+    cursor: pointer;
+    transition: transform 0.2s ease, border 0.2s ease, box-shadow 0.2s ease;
+    min-width: 210px;
+  }
+
+  .track-chip:hover {
+    transform: translateY(-2px);
+    border-color: rgba(120, 210, 185, 0.4);
+    box-shadow: 0 14px 30px rgba(15, 18, 26, 0.55);
+  }
+
+  .track-chip.selected {
+    border-color: rgba(120, 210, 185, 0.6);
+    box-shadow: 0 18px 40px rgba(120, 210, 185, 0.2);
+  }
+
+  .chip-strip {
+    width: 12px;
+    height: 100%;
+    border-radius: 999px;
+  }
+
+  .chip-content {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .chip-name {
+    font-weight: 600;
+    font-size: 1rem;
+    letter-spacing: 0.04em;
+  }
+
+  .chip-meta {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: rgba(255, 255, 255, 0.5);
+  }
+
+  .control-panel {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 20px;
+    padding: 20px;
+    border-radius: 20px;
+    background: linear-gradient(130deg, rgba(20, 24, 32, 0.95), rgba(14, 16, 22, 0.92));
+    border: 1px solid rgba(255, 255, 255, 0.04);
+  }
+
+  .control {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    color: #fff;
+    font-size: 0.8rem;
+  }
+
+  .control label {
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    font-weight: 600;
+    color: rgba(255, 255, 255, 0.6);
+  }
+
+  select,
+  input[type='number'],
+  input[type='range'] {
+    background: rgba(0, 0, 0, 0.35);
+    color: #fff;
+    border-radius: 12px;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    padding: 8px 12px;
+    font-size: 0.95rem;
+  }
+
+  select:focus,
+  input[type='number']:focus,
+  input[type='range']:focus {
+    outline: 2px solid rgba(120, 210, 185, 0.5);
+    outline-offset: 2px;
+  }
+
+  .number-field input {
+    width: 72px;
+    text-align: center;
+    font-weight: 600;
+    appearance: textfield;
+  }
+
+  .number-field input::-webkit-outer-spin-button,
+  .number-field input::-webkit-inner-spin-button {
+    appearance: none;
+    margin: 0;
+  }
+
+  .volume {
+    position: relative;
+  }
+
+  .volume input[type='range'] {
+    width: 100%;
+  }
+
+  .volume-value {
+    position: absolute;
+    top: -20px;
+    right: 0;
+    font-size: 0.75rem;
+    color: rgba(255, 255, 255, 0.6);
+  }
+
+  .toggles {
+    display: flex;
+    gap: 10px;
+  }
+
+  .toggles button {
+    flex: 1;
+    padding: 10px 12px;
+    border-radius: 12px;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    background: rgba(255, 255, 255, 0.04);
+    color: rgba(255, 255, 255, 0.75);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-size: 0.75rem;
+    cursor: pointer;
+    transition: border-color 0.2s ease, background 0.2s ease;
+  }
+
+  .toggles button.active {
+    border-color: rgba(120, 210, 185, 0.6);
+    background: rgba(120, 210, 185, 0.2);
+    color: #fff;
+  }
+
+  </style>

--- a/bitloops_app/src/components/Transport.svelte
+++ b/bitloops_app/src/components/Transport.svelte
@@ -1,29 +1,180 @@
 <script>
-  export let playing = false;
-  export let follow = false;
+  import { createEventDispatcher } from 'svelte';
 
-  const togglePlay = () => {
-    const event = new CustomEvent('toggleplay');
-    dispatchEvent(event);
+  export let playing = false;
+  export let follow = true;
+  export let bpm = 120;
+
+  const dispatch = createEventDispatcher();
+
+  const handlePlayClick = () => {
+    dispatch('toggleplay');
   };
-  const toggleFollow = () => {
-    const event = new CustomEvent('togglefollow');
-    dispatchEvent(event);
+
+  const handleFollowClick = () => {
+    dispatch('togglefollow', { value: !follow });
+  };
+
+  const handleBpmChange = (event) => {
+    const value = Number(event.target.value);
+    if (!Number.isNaN(value)) {
+      dispatch('changebpm', { value });
+    }
   };
 </script>
 
-<div class="flex flex-col items-center space-y-2 p-2 bg-panel">
-  <button class="bg-accent text-panel px-4 py-2 rounded" on:click={togglePlay}>
-    {playing ? 'Stop' : 'Play'}
+<div class="transport">
+  <button class="play-button" class:active={playing} on:click={handlePlayClick} type="button">
+    <span class="icon" aria-hidden="true">{playing ? '■' : '▶'}</span>
+    <span class="label">{playing ? 'Stop' : 'Play'}</span>
   </button>
-  <button class="bg-panel text-accent border border-accent px-2 py-1 rounded" on:click={toggleFollow}>
-    {follow ? 'Following' : 'Free'}
-  </button>
+  <div class="transport-controls">
+    <button class="follow" class:active={follow} on:click={handleFollowClick} type="button">
+      <span class="indicator" aria-hidden="true"></span>
+      <span>{follow ? 'Following' : 'Follow'}</span>
+    </button>
+    <label class="tempo">
+      <span class="tempo-label">Tempo</span>
+      <div class="tempo-field">
+        <input type="number" min="30" max="260" value={bpm} on:input={handleBpmChange} />
+        <span class="suffix">BPM</span>
+      </div>
+    </label>
+  </div>
 </div>
 
 <style>
-  .bg-panel { background-color: var(--panel); }
-  .text-panel { color: var(--panel); }
-  .bg-accent { background-color: var(--accent); }
-  .text-accent { color: var(--accent); }
+  .transport {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+  }
+
+  .play-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 12px;
+    padding: 16px 20px;
+    border-radius: 18px;
+    border: 1px solid rgba(120, 210, 185, 0.32);
+    background: linear-gradient(135deg, rgba(120, 210, 185, 0.18), rgba(22, 26, 36, 0.85));
+    color: #fff;
+    font-size: 1.1rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    box-shadow: 0 18px 40px rgba(120, 210, 185, 0.2);
+  }
+
+  .play-button .icon {
+    width: 24px;
+    height: 24px;
+    display: grid;
+    place-items: center;
+    border-radius: 999px;
+    background: rgba(0, 0, 0, 0.4);
+    font-size: 0.9rem;
+  }
+
+  .play-button:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 22px 44px rgba(120, 210, 185, 0.28);
+  }
+
+  .play-button.active {
+    background: linear-gradient(135deg, rgba(246, 142, 175, 0.25), rgba(22, 26, 36, 0.85));
+    border-color: rgba(246, 142, 175, 0.32);
+  }
+
+  .transport-controls {
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+  }
+
+  .follow {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 14px;
+    border-radius: 12px;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    background: rgba(255, 255, 255, 0.04);
+    color: rgba(255, 255, 255, 0.85);
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    cursor: pointer;
+    transition: border-color 0.2s ease, background 0.2s ease;
+  }
+
+  .follow .indicator {
+    width: 10px;
+    height: 10px;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.18);
+    box-shadow: 0 0 0 0 rgba(120, 210, 185, 0.35);
+    transition: background 0.2s ease, box-shadow 0.2s ease;
+  }
+
+  .follow.active {
+    border-color: rgba(120, 210, 185, 0.5);
+    background: rgba(120, 210, 185, 0.16);
+    color: #fff;
+  }
+
+  .follow.active .indicator {
+    background: var(--accent);
+    box-shadow: 0 0 12px rgba(120, 210, 185, 0.6);
+  }
+
+  .tempo {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    font-size: 0.8rem;
+    color: rgba(255, 255, 255, 0.6);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+
+  .tempo-label {
+    font-weight: 600;
+  }
+
+  .tempo-field {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 12px;
+    border-radius: 12px;
+    background: rgba(0, 0, 0, 0.45);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+  }
+
+  .tempo-field input {
+    appearance: textfield;
+    width: 72px;
+    background: transparent;
+    border: none;
+    color: #fff;
+    font-size: 1rem;
+    font-weight: 600;
+    outline: none;
+  }
+
+  .tempo-field input::-webkit-outer-spin-button,
+  .tempo-field input::-webkit-inner-spin-button {
+    appearance: none;
+    margin: 0;
+  }
+
+  .suffix {
+    font-size: 0.75rem;
+    color: rgba(255, 255, 255, 0.45);
+    letter-spacing: 0.1em;
+  }
 </style>

--- a/bitloops_app/src/components/__tests__/Transport.spec.js
+++ b/bitloops_app/src/components/__tests__/Transport.spec.js
@@ -1,0 +1,29 @@
+import { render, fireEvent } from '@testing-library/svelte';
+import { describe, it, expect, vi } from 'vitest';
+import Transport from '../Transport.svelte';
+
+describe('Transport component', () => {
+  it('emits toggle events', async () => {
+    const { component, getByText } = render(Transport, {
+      props: { playing: false, follow: true, bpm: 120 }
+    });
+
+    const togglePlay = vi.fn();
+    const toggleFollow = vi.fn();
+    const changeBpm = vi.fn();
+
+    component.$on('toggleplay', togglePlay);
+    component.$on('togglefollow', toggleFollow);
+    component.$on('changebpm', changeBpm);
+
+    await fireEvent.click(getByText('Play'));
+    expect(togglePlay).toHaveBeenCalled();
+
+    await fireEvent.click(getByText('Following'));
+    expect(toggleFollow).toHaveBeenCalledWith(expect.objectContaining({ detail: { value: false } }));
+
+    const input = document.querySelector('input[type="number"]');
+    await fireEvent.input(input, { target: { value: '140' } });
+    expect(changeBpm).toHaveBeenCalledWith(expect.objectContaining({ detail: { value: 140 } }));
+  });
+});

--- a/bitloops_app/src/lib/scheduler.js
+++ b/bitloops_app/src/lib/scheduler.js
@@ -1,15 +1,15 @@
 /**
- * Simple placeholder for the audio scheduler.
+ * BitLoops WebAudio scheduler with lookahead.
  *
- * The scheduler should implement a lookahead loop that queues events ahead
- * of the current playback time to ensure smooth playback. It should also
- * provide start/stop functions and expose a callback when each step begins.
+ * The scheduler queues playback steps slightly ahead of the audio clock to
+ * ensure smooth playback. Consumers should provide an `onStep` callback which
+ * receives `(stepIndex, stepStartTime, stepDuration)`.
  */
-
 export class Scheduler {
-  constructor(context, tempo = 120) {
+  constructor(context, tempo = 120, stepsPerBeat = 4) {
     this.context = context;
     this.tempo = tempo;
+    this.stepsPerBeat = stepsPerBeat;
     this.isPlaying = false;
     this.currentStep = 0;
     this.lookahead = 0.1; // seconds
@@ -18,26 +18,41 @@ export class Scheduler {
     this.onStep = () => {};
     this.nextStepTime = 0;
   }
+
+  setTempo(tempo) {
+    this.tempo = tempo;
+  }
+
+  setStepsPerBeat(stepsPerBeat) {
+    this.stepsPerBeat = stepsPerBeat;
+  }
+
   start() {
     if (this.isPlaying) return;
     this.isPlaying = true;
     this.currentStep = 0;
+    this.nextStepTime = this.context.currentTime;
     this.schedule();
   }
+
   stop() {
     this.isPlaying = false;
     clearTimeout(this.timerID);
+    this.timerID = null;
   }
+
   schedule() {
     if (!this.isPlaying) return;
     const secondsPerBeat = 60 / this.tempo;
-    const secondsPerStep = secondsPerBeat / 4; // default 16th note resolution
+    const secondsPerStep = secondsPerBeat / this.stepsPerBeat;
     const now = this.context.currentTime;
+
     while (this.nextStepTime < now + this.scheduleAhead) {
-      this.onStep(this.currentStep, this.nextStepTime);
+      this.onStep(this.currentStep, this.nextStepTime, secondsPerStep);
       this.nextStepTime += secondsPerStep;
-      this.currentStep++;
+      this.currentStep += 1;
     }
+
     this.timerID = setTimeout(() => this.schedule(), this.lookahead * 1000);
   }
 }

--- a/bitloops_app/src/store/__tests__/projectStore.spec.js
+++ b/bitloops_app/src/store/__tests__/projectStore.spec.js
@@ -1,0 +1,41 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { project, totalSteps, loopDuration } from '../projectStore.js';
+import { get } from 'svelte/store';
+
+const resetStore = () => {
+  const snapshot = project.serialize();
+  project.load(snapshot);
+};
+
+describe('project store', () => {
+  beforeEach(() => {
+    resetStore();
+  });
+
+  it('toggles notes within bounds', () => {
+    const before = get(project);
+    expect(before.tracks[0].notes[0][0]).toBe(false);
+    project.toggleNote(0, 0, 0, true);
+    const after = get(project);
+    expect(after.tracks[0].notes[0][0]).toBe(true);
+  });
+
+  it('clamps bars when exceeding five minute limit', () => {
+    const initialSteps = get(totalSteps);
+    expect(initialSteps).toBeGreaterThan(0);
+    project.setBpm(60);
+    project.setBars(400);
+    const state = get(project);
+    const seconds = get(loopDuration);
+    expect(state.bars).toBeLessThanOrEqual(300);
+    expect(seconds).toBeLessThanOrEqual(300);
+  });
+
+  it('enforces solo exclusivity', () => {
+    project.setTrackSetting(0, 'solo', true);
+    project.setTrackSetting(1, 'solo', true);
+    const state = get(project);
+    expect(state.tracks[0].solo).toBe(false);
+    expect(state.tracks[1].solo).toBe(true);
+  });
+});

--- a/bitloops_app/src/store/projectStore.js
+++ b/bitloops_app/src/store/projectStore.js
@@ -1,0 +1,290 @@
+import { writable, derived, get } from 'svelte/store';
+import { scales } from '../lib/scales.js';
+
+export const MAX_LOOP_SECONDS = 300;
+
+const DEFAULT_ROWS = 8;
+const DEFAULT_BARS = 4;
+const DEFAULT_STEPS_PER_BAR = 16;
+const DEFAULT_BPM = 120;
+const DEFAULT_FOLLOW = true;
+const TRACK_COLORS = ['#78D2B9', '#A88EF6', '#F6C58E', '#F68EAF', '#8EF6D1'];
+
+const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
+
+const createEmptyPattern = (rows, steps) =>
+  Array.from({ length: rows }, () => Array.from({ length: steps }, () => false));
+
+const resizeTrack = (track, rows, steps) => {
+  const notes = Array.from({ length: rows }, (_, rowIndex) => {
+    const row = track.notes?.[rowIndex] ?? [];
+    const padded = row.slice(0, steps);
+    if (padded.length < steps) {
+      padded.push(...Array.from({ length: steps - padded.length }, () => false));
+    }
+    return padded;
+  });
+  return { ...track, notes };
+};
+
+const normalizeTracks = (tracks, rows, steps) =>
+  tracks.map((track, index) => {
+    const color = track.color ?? TRACK_COLORS[index % TRACK_COLORS.length];
+    const waveform = track.waveform ?? 'square';
+    const scaleName = scales[track.scale] ? track.scale : 'major';
+    const octave = clamp(track.octave ?? 4, 1, 7);
+    const volume = clamp(track.volume ?? 0.7, 0, 1);
+    return resizeTrack(
+      {
+        id: track.id ?? index + 1,
+        name: track.name ?? `Track ${index + 1}`,
+        color,
+        waveform,
+        scale: scaleName,
+        octave,
+        volume,
+        mute: !!track.mute,
+        solo: !!track.solo,
+        notes: track.notes ?? createEmptyPattern(DEFAULT_ROWS, DEFAULT_STEPS_PER_BAR * DEFAULT_BARS)
+      },
+      rows,
+      steps
+    );
+  });
+
+const createTrack = (index, rows, steps) =>
+  resizeTrack(
+    {
+      id: index + 1,
+      name: `Track ${index + 1}`,
+      color: TRACK_COLORS[index % TRACK_COLORS.length],
+      waveform: 'square',
+      scale: 'major',
+      octave: 4,
+      volume: 0.7,
+      mute: false,
+      solo: false,
+      notes: createEmptyPattern(rows, steps)
+    },
+    rows,
+    steps
+  );
+
+const calculateSecondsPerBar = (bpm) => (240 / bpm);
+
+const calculateMaxBars = (bpm) => {
+  const secondsPerBar = calculateSecondsPerBar(bpm);
+  return Math.max(1, Math.floor(MAX_LOOP_SECONDS / secondsPerBar));
+};
+
+const normalizeState = (state) => {
+  const steps = state.bars * state.stepsPerBar;
+  const rows = state.rows;
+  const tracks = normalizeTracks(state.tracks, rows, steps);
+  const selectedTrack = clamp(state.selectedTrack ?? 0, 0, Math.max(tracks.length - 1, 0));
+  const playheadStep = state.playheadStep % (steps || 1);
+  return {
+    rows,
+    bars: state.bars,
+    stepsPerBar: state.stepsPerBar,
+    bpm: state.bpm,
+    follow: state.follow,
+    playing: state.playing,
+    selectedTrack,
+    playheadStep,
+    playheadProgress: state.playheadProgress ?? 0,
+    lastStepTime: state.lastStepTime ?? 0,
+    nextStepTime: state.nextStepTime ?? 0,
+    tracks
+  };
+};
+
+const initialState = normalizeState({
+  rows: DEFAULT_ROWS,
+  bars: DEFAULT_BARS,
+  stepsPerBar: DEFAULT_STEPS_PER_BAR,
+  bpm: DEFAULT_BPM,
+  follow: DEFAULT_FOLLOW,
+  playing: false,
+  selectedTrack: 0,
+  playheadStep: 0,
+  playheadProgress: 0,
+  lastStepTime: 0,
+  nextStepTime: 0,
+  tracks: [createTrack(0, DEFAULT_ROWS, DEFAULT_BARS * DEFAULT_STEPS_PER_BAR), createTrack(1, DEFAULT_ROWS, DEFAULT_BARS * DEFAULT_STEPS_PER_BAR)]
+});
+
+const ensureBarsWithinLimit = (bpm, desiredBars) => {
+  const maxBars = calculateMaxBars(bpm);
+  return Math.min(desiredBars, maxBars);
+};
+
+const ensurePositiveInteger = (value, fallback, min = 1, max = Number.POSITIVE_INFINITY) => {
+  const parsed = Number.isFinite(value) ? value : parseInt(value, 10);
+  if (Number.isFinite(parsed)) {
+    return clamp(Math.round(parsed), min, max);
+  }
+  return clamp(fallback, min, max);
+};
+
+const createProjectStore = () => {
+  const store = writable(initialState);
+  const { subscribe, set, update } = store;
+
+  return {
+    subscribe,
+    toggleNote(trackIndex, row, step, value) {
+      update((state) => {
+        const totalSteps = state.bars * state.stepsPerBar;
+        if (
+          trackIndex < 0 ||
+          trackIndex >= state.tracks.length ||
+          row < 0 ||
+          row >= state.rows ||
+          step < 0 ||
+          step >= totalSteps
+        ) {
+          return state;
+        }
+        const tracks = state.tracks.map((track, idx) => {
+          if (idx !== trackIndex) return track;
+          const notes = track.notes.map((rowNotes) => rowNotes.slice());
+          notes[row][step] = value ?? !notes[row][step];
+          return { ...track, notes };
+        });
+        return { ...state, tracks };
+      });
+    },
+    setPlaying(playing) {
+      update((state) => ({ ...state, playing }));
+    },
+    setFollow(follow) {
+      update((state) => ({ ...state, follow }));
+    },
+    selectTrack(index) {
+      update((state) => ({ ...state, selectedTrack: clamp(index, 0, Math.max(state.tracks.length - 1, 0)) }));
+    },
+    setBpm(value) {
+      update((state) => {
+        const bpm = clamp(value, 30, 260);
+        const bars = ensureBarsWithinLimit(bpm, state.bars);
+        const next = normalizeState({ ...state, bpm, bars });
+        return next;
+      });
+    },
+    setBars(value) {
+      update((state) => {
+        const bars = ensureBarsWithinLimit(state.bpm, ensurePositiveInteger(value, state.bars, 1, 512));
+        const next = normalizeState({ ...state, bars });
+        return next;
+      });
+    },
+    setStepsPerBar(value) {
+      update((state) => {
+        const stepsPerBar = ensurePositiveInteger(value, state.stepsPerBar, 4, 64);
+        const next = normalizeState({ ...state, stepsPerBar });
+        return next;
+      });
+    },
+    setTrackSetting(trackIndex, key, value) {
+      update((state) => {
+        if (trackIndex < 0 || trackIndex >= state.tracks.length) return state;
+        const nextTracks = state.tracks.map((track, idx) => {
+          if (idx !== trackIndex) return track;
+          if (key === 'volume') {
+            return { ...track, volume: clamp(value, 0, 1) };
+          }
+          if (key === 'octave') {
+            return { ...track, octave: clamp(value, 1, 7) };
+          }
+          if (key === 'mute' || key === 'solo') {
+            return { ...track, [key]: !!value };
+          }
+          if (key === 'scale' && !scales[value]) {
+            return track;
+          }
+          return { ...track, [key]: value };
+        });
+        let tracks = nextTracks;
+        if (key === 'solo' && value) {
+          tracks = nextTracks.map((track, idx) =>
+            idx === trackIndex ? track : { ...track, solo: false }
+          );
+        }
+        return { ...state, tracks };
+      });
+    },
+    registerStep(step, stepTime, stepDuration) {
+      update((state) => ({
+        ...state,
+        playheadStep: step,
+        playheadProgress: 0,
+        lastStepTime: stepTime,
+        nextStepTime: stepTime + stepDuration
+      }));
+    },
+    setPlayheadProgress(progress) {
+      update((state) => ({ ...state, playheadProgress: clamp(progress, 0, 1) }));
+    },
+    resetPlayhead() {
+      update((state) => ({ ...state, playheadStep: 0, playheadProgress: 0, lastStepTime: 0, nextStepTime: 0 }));
+    },
+    serialize() {
+      const snapshot = get(store);
+      return {
+        version: 1,
+        rows: snapshot.rows,
+        bars: snapshot.bars,
+        stepsPerBar: snapshot.stepsPerBar,
+        bpm: snapshot.bpm,
+        tracks: snapshot.tracks.map((track) => ({
+          id: track.id,
+          name: track.name,
+          color: track.color,
+          waveform: track.waveform,
+          scale: track.scale,
+          octave: track.octave,
+          volume: track.volume,
+          mute: track.mute,
+          solo: track.solo,
+          notes: track.notes
+        }))
+      };
+    },
+    load(payload) {
+      if (!payload || typeof payload !== 'object') return false;
+      const rows = ensurePositiveInteger(payload.rows, DEFAULT_ROWS, 1, 32);
+      const bpm = clamp(payload.bpm ?? DEFAULT_BPM, 30, 260);
+      const maxBars = calculateMaxBars(bpm);
+      const bars = clamp(payload.bars ?? DEFAULT_BARS, 1, maxBars);
+      const stepsPerBar = ensurePositiveInteger(payload.stepsPerBar, DEFAULT_STEPS_PER_BAR, 4, 64);
+      const tracksPayload = Array.isArray(payload.tracks) && payload.tracks.length > 0 ? payload.tracks : undefined;
+      const tracks = tracksPayload
+        ? normalizeTracks(tracksPayload, rows, bars * stepsPerBar)
+        : [createTrack(0, rows, bars * stepsPerBar)];
+      set(
+        normalizeState({
+          rows,
+          bars,
+          stepsPerBar,
+          bpm,
+          follow: payload.follow ?? DEFAULT_FOLLOW,
+          playing: false,
+          selectedTrack: clamp(payload.selectedTrack ?? 0, 0, Math.max(tracks.length - 1, 0)),
+          playheadStep: 0,
+          playheadProgress: 0,
+          lastStepTime: 0,
+          nextStepTime: 0,
+          tracks
+        })
+      );
+      return true;
+    }
+  };
+};
+
+export const project = createProjectStore();
+
+export const totalSteps = derived(project, ($project) => $project.bars * $project.stepsPerBar);
+export const loopDuration = derived(project, ($project) => ($project.bars * 240) / $project.bpm);
+export const maxBars = derived(project, ($project) => calculateMaxBars($project.bpm));

--- a/bitloops_app/svelte.config.js
+++ b/bitloops_app/svelte.config.js
@@ -1,0 +1,13 @@
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
+
+const config = {
+  compilerOptions: {
+    dev: false
+  },
+  preprocess: vitePreprocess(),
+  kit: {
+    adapter: undefined
+  }
+};
+
+export default config;

--- a/bitloops_app/vite.config.js
+++ b/bitloops_app/vite.config.js
@@ -1,0 +1,20 @@
+import { defineConfig } from 'vite';
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+import path from 'path';
+
+export default defineConfig({
+  root: '.',
+  plugins: [svelte()],
+  resolve: {
+    alias: {
+      $components: path.resolve(__dirname, 'src/components'),
+      $lib: path.resolve(__dirname, 'src/lib'),
+      $store: path.resolve(__dirname, 'src/store'),
+      $src: path.resolve(__dirname, 'src')
+    }
+  },
+  server: {
+    host: '0.0.0.0',
+    port: 5173
+  }
+});

--- a/bitloops_app/vitest.config.js
+++ b/bitloops_app/vitest.config.js
@@ -1,0 +1,18 @@
+import { defineConfig, mergeConfig } from 'vitest/config';
+import viteConfig from './vite.config.js';
+
+export default mergeConfig(
+  viteConfig,
+  defineConfig({
+    test: {
+      environment: 'jsdom',
+      globals: true,
+      setupFiles: ['./vitest.setup.js'],
+      coverage: {
+        provider: 'v8',
+        reporter: ['text', 'html'],
+        reportsDirectory: './coverage'
+      }
+    }
+  })
+);

--- a/bitloops_app/vitest.setup.js
+++ b/bitloops_app/vitest.setup.js
@@ -1,0 +1,90 @@
+import { afterEach, beforeAll, vi } from 'vitest';
+import { cleanup } from '@testing-library/svelte';
+
+beforeAll(() => {
+  if (!globalThis.window) {
+    globalThis.window = globalThis;
+  }
+
+  if (!globalThis.requestAnimationFrame) {
+    globalThis.requestAnimationFrame = (cb) => setTimeout(() => cb(Date.now()), 16);
+  }
+
+  if (!globalThis.cancelAnimationFrame) {
+    globalThis.cancelAnimationFrame = (id) => clearTimeout(id);
+  }
+
+  if (!globalThis.ResizeObserver) {
+    globalThis.ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+  }
+
+  if (!globalThis.AudioContext) {
+    class MockAudioContext {
+      constructor() {
+        this.currentTime = 0;
+      }
+      resume = vi.fn(async () => {});
+      createGain() {
+        return {
+          gain: { setValueAtTime: vi.fn() },
+          connect: vi.fn()
+        };
+      }
+      createOscillator() {
+        return {
+          type: 'sine',
+          frequency: { setValueAtTime: vi.fn() },
+          connect: vi.fn(),
+          start: vi.fn(),
+          stop: vi.fn()
+        };
+      }
+      createBuffer() {
+        return {
+          getChannelData: () => new Float32Array(1)
+        };
+      }
+      createBufferSource() {
+        return {
+          connect: vi.fn(),
+          start: vi.fn(),
+          stop: vi.fn()
+        };
+      }
+      close = vi.fn(async () => {});
+      destination = {};
+    }
+    globalThis.AudioContext = MockAudioContext;
+    globalThis.webkitAudioContext = MockAudioContext;
+  }
+
+  if (!HTMLCanvasElement.prototype.getContext) {
+    HTMLCanvasElement.prototype.getContext = vi.fn(() => ({
+      setTransform: vi.fn(),
+      clearRect: vi.fn(),
+      fillRect: vi.fn(),
+      beginPath: vi.fn(),
+      moveTo: vi.fn(),
+      lineTo: vi.fn(),
+      stroke: vi.fn(),
+      arc: vi.fn(),
+      fill: vi.fn(),
+      strokeRect: vi.fn(),
+      fillStyle: '',
+      strokeStyle: '',
+      lineWidth: 1,
+      shadowColor: '',
+      shadowBlur: 0,
+      font: '',
+      measureText: vi.fn(() => ({ width: 0 }))
+    }));
+  }
+});
+
+afterEach(() => {
+  cleanup();
+});


### PR DESCRIPTION
## Summary
- redesign the application shell with a new side rail, session header, and status pills for a sleeker layout
- update the canvas renderer to emphasise glowing dots, measure washes, and playhead glow while honouring steps-per-bar shading
- restyle the transport, track controls, and footer actions to match the refined design and provide clearer feedback

## Testing
- npm test -- --run *(fails: vitest binary unavailable without npm install in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fdb9d112083269dcdf1ae1c2c6746)