### PR TITLE
Fix Svelte store usage and align design tokens

### DIFF
--- a/bitloops_app/src/components/Footer.svelte
+++ b/bitloops_app/src/components/Footer.svelte
@@ -152,8 +152,8 @@
     gap: 4px;
     padding: 16px 18px;
     border-radius: 16px;
-    background: linear-gradient(135deg, rgba(120, 210, 255, 0.18), rgba(14, 16, 22, 0.9));
-    border: 1px solid rgba(120, 210, 255, 0.25);
+    background: linear-gradient(135deg, rgba(var(--color-note-active-rgb), 0.18), rgba(14, 16, 22, 0.9));
+    border: 1px solid rgba(var(--color-note-active-rgb), 0.25);
     min-width: 150px;
   }
 
@@ -203,9 +203,9 @@
   }
 
   .primary {
-    border: 1px solid rgba(120, 210, 185, 0.6);
-    background: rgba(120, 210, 185, 0.22);
+    border: 1px solid rgba(var(--color-accent-rgb), 0.6);
+    background: rgba(var(--color-accent-rgb), 0.22);
     color: #fff;
-    box-shadow: 0 16px 40px rgba(120, 210, 185, 0.3);
+    box-shadow: 0 16px 40px rgba(var(--color-accent-rgb), 0.3);
   }
 </style>

--- a/bitloops_app/src/components/Grid.svelte
+++ b/bitloops_app/src/components/Grid.svelte
@@ -1,5 +1,6 @@
 <script>
   import { createEventDispatcher, onDestroy, onMount } from 'svelte';
+  import { colors } from '../lib/colorTokens.js';
 
   export let notes = [];
   export let rows = 8;
@@ -7,7 +8,7 @@ export let columns = 16;
 export let stepsPerBar = 16;
   export let playheadStep = 0;
   export let playheadProgress = 0;
-  export let trackColor = '#78D2B9';
+  export let trackColor = colors.accent;
   export let follow = true;
   export let isPlaying = false;
 
@@ -23,8 +24,8 @@ export let stepsPerBar = 16;
   let resizeObserver;
 
   const hexToRgba = (hex, alpha = 1) => {
-    if (!hex) return `rgba(120, 210, 185, ${alpha})`;
-    const clean = hex.replace('#', '');
+    const fallback = hex ?? colors.accent;
+    const clean = fallback.replace('#', '');
     const bigint = parseInt(clean.length === 3 ? clean.replace(/(.)/g, '$1$1') : clean, 16);
     const r = (bigint >> 16) & 255;
     const g = (bigint >> 8) & 255;
@@ -35,10 +36,12 @@ export let stepsPerBar = 16;
   const getStyles = () => {
     const style = getComputedStyle(canvas);
     return {
-      background: style.getPropertyValue('--panel')?.trim() || '#161A24',
-      grid: style.getPropertyValue('--grid-line')?.trim() || 'rgba(255,255,255,0.08)',
-      inactive: style.getPropertyValue('--note-inactive')?.trim() || '#3C4450',
-      playhead: style.getPropertyValue('--playhead')?.trim() || hexToRgba(trackColor, 0.9)
+      background: style.getPropertyValue('--color-panel')?.trim() || colors.panel,
+      grid: style.getPropertyValue('--color-grid-line')?.trim() || 'rgba(255,255,255,0.08)',
+      inactive:
+        style.getPropertyValue('--color-note-inactive')?.trim() || colors.noteInactive,
+      playhead:
+        style.getPropertyValue('--color-playhead')?.trim() || hexToRgba(trackColor, 0.9)
     };
   };
 
@@ -262,7 +265,7 @@ export let stepsPerBar = 16;
     height: 100%;
     overflow-x: auto;
     overflow-y: hidden;
-    background: var(--panel);
+    background: var(--color-panel);
     border-radius: 12px;
     border: 1px solid rgba(255, 255, 255, 0.05);
   }

--- a/bitloops_app/src/components/TrackBar.svelte
+++ b/bitloops_app/src/components/TrackBar.svelte
@@ -129,7 +129,7 @@
   .track-list {
     display: grid;
     grid-auto-flow: column;
-    grid-auto-columns: minmax(210px, 1fr);
+    grid-auto-columns: minmax(110px, 1fr);
     gap: 16px;
     overflow-x: auto;
     padding-bottom: 6px;
@@ -141,7 +141,7 @@
   }
 
   .track-list::-webkit-scrollbar-thumb {
-    background: rgba(120, 210, 185, 0.3);
+    background: rgba(var(--color-accent-rgb), 0.3);
     border-radius: 999px;
   }
 
@@ -158,18 +158,18 @@
     gap: 14px;
     cursor: pointer;
     transition: transform 0.2s ease, border 0.2s ease, box-shadow 0.2s ease;
-    min-width: 210px;
+    min-width: 110px;
   }
 
   .track-chip:hover {
     transform: translateY(-2px);
-    border-color: rgba(120, 210, 185, 0.4);
+    border-color: rgba(var(--color-accent-rgb), 0.4);
     box-shadow: 0 14px 30px rgba(15, 18, 26, 0.55);
   }
 
   .track-chip.selected {
-    border-color: rgba(120, 210, 185, 0.6);
-    box-shadow: 0 18px 40px rgba(120, 210, 185, 0.2);
+    border-color: rgba(var(--color-accent-rgb), 0.6);
+    box-shadow: 0 18px 40px rgba(var(--color-accent-rgb), 0.2);
   }
 
   .chip-strip {
@@ -236,7 +236,7 @@
   select:focus,
   input[type='number']:focus,
   input[type='range']:focus {
-    outline: 2px solid rgba(120, 210, 185, 0.5);
+    outline: 2px solid rgba(var(--color-accent-rgb), 0.5);
     outline-offset: 2px;
   }
 
@@ -289,8 +289,8 @@
   }
 
   .toggles button.active {
-    border-color: rgba(120, 210, 185, 0.6);
-    background: rgba(120, 210, 185, 0.2);
+    border-color: rgba(var(--color-accent-rgb), 0.6);
+    background: rgba(var(--color-accent-rgb), 0.2);
     color: #fff;
   }
 

--- a/bitloops_app/src/components/Transport.svelte
+++ b/bitloops_app/src/components/Transport.svelte
@@ -57,8 +57,8 @@
     gap: 12px;
     padding: 16px 20px;
     border-radius: 18px;
-    border: 1px solid rgba(120, 210, 185, 0.32);
-    background: linear-gradient(135deg, rgba(120, 210, 185, 0.18), rgba(22, 26, 36, 0.85));
+    border: 1px solid rgba(var(--color-accent-rgb), 0.32);
+    background: linear-gradient(135deg, rgba(var(--color-accent-rgb), 0.18), rgba(22, 26, 36, 0.85));
     color: #fff;
     font-size: 1.1rem;
     font-weight: 600;
@@ -66,7 +66,7 @@
     text-transform: uppercase;
     cursor: pointer;
     transition: transform 0.2s ease, box-shadow 0.2s ease;
-    box-shadow: 0 18px 40px rgba(120, 210, 185, 0.2);
+    box-shadow: 0 18px 40px rgba(var(--color-accent-rgb), 0.2);
   }
 
   .play-button .icon {
@@ -81,7 +81,7 @@
 
   .play-button:hover {
     transform: translateY(-2px);
-    box-shadow: 0 22px 44px rgba(120, 210, 185, 0.28);
+    box-shadow: 0 22px 44px rgba(var(--color-accent-rgb), 0.28);
   }
 
   .play-button.active {
@@ -116,19 +116,19 @@
     height: 10px;
     border-radius: 999px;
     background: rgba(255, 255, 255, 0.18);
-    box-shadow: 0 0 0 0 rgba(120, 210, 185, 0.35);
+    box-shadow: 0 0 0 0 rgba(var(--color-accent-rgb), 0.35);
     transition: background 0.2s ease, box-shadow 0.2s ease;
   }
 
   .follow.active {
-    border-color: rgba(120, 210, 185, 0.5);
-    background: rgba(120, 210, 185, 0.16);
+    border-color: rgba(var(--color-accent-rgb), 0.5);
+    background: rgba(var(--color-accent-rgb), 0.16);
     color: #fff;
   }
 
   .follow.active .indicator {
-    background: var(--accent);
-    box-shadow: 0 0 12px rgba(120, 210, 185, 0.6);
+    background: var(--color-accent);
+    box-shadow: 0 0 12px rgba(var(--color-accent-rgb), 0.6);
   }
 
   .tempo {


### PR DESCRIPTION
## Summary
- replace the invalid $-prefixed local bindings in `App.svelte` with explicit subscriptions and derived values so the app compiles
- expose the BitLoops color tokens through global utility-style classes and update components to consume the shared variables
- resize the track bar chips to the 110px width required by the design spec while keeping the 12px accent strip

## Testing
- npm run check

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910058d09948326b0db6f1fb360d42a)