### PR TITLE
Restore Svelte app structure under bitloops_app

### DIFF
--- a/bitloops_app/index.html
+++ b/bitloops_app/index.html
@@ -1,12 +1,11 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>BitLoops</title>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tailwindcss@3.3.0/dist/tailwind.min.css" />
   </head>
-  <body class="bg-[#0E1016] text-white">
+  <body class="bg-bg text-white">
     <div id="app"></div>
     <script type="module" src="/src/main.js"></script>
   </body>

--- a/bitloops_app/package.json
+++ b/bitloops_app/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "bitloops-app",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "devDependencies": {
+    "@sveltejs/vite-plugin-svelte": "^4.0.0",
+    "autoprefixer": "^10.4.19",
+    "postcss": "^8.4.38",
+    "svelte": "^4.2.0",
+    "tailwindcss": "^3.4.0",
+    "vite": "^5.0.0"
+  }
+}

--- a/bitloops_app/postcss.config.cjs
+++ b/bitloops_app/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/bitloops_app/src/App.svelte
+++ b/bitloops_app/src/App.svelte
@@ -1,52 +1,53 @@
 <script>
-  import Grid from './components/Grid.svelte';
-  import TrackBar from './components/TrackBar.svelte';
-  import Transport from './components/Transport.svelte';
-  import Footer from './components/Footer.svelte';
-  import { project } from './store/projectStore.js';
+  import Grid from '$components/Grid.svelte';
+  import TrackBar from '$components/TrackBar.svelte';
+  import Transport from '$components/Transport.svelte';
+  import Footer from '$components/Footer.svelte';
+  import { project } from '$store/projectStore.js';
 
-  // Temporary local state for demonstration
-  let selectedTrack = 0;
-  let tracks = [
-    { name: 'Track 1', color: '#78D2B9' },
-    { name: 'Track 2', color: '#A88EF6' }
-  ];
-  let playing = false;
-  let follow = false;
-  let activeNotes = Array(8).fill().map(() => Array(16).fill(false));
+  const handleToggle = ({ detail }) => {
+    project.toggleNote(detail.row, detail.col);
+  };
 
-  const handleToggle = (event) => {
-    const { row, col } = event.detail;
-    activeNotes[row][col] = !activeNotes[row][col];
+  const handleSelect = ({ detail }) => {
+    project.selectTrack(detail.index);
   };
-  const handleSelect = (event) => {
-    selectedTrack = event.detail.index;
-  };
+
   const handleTogglePlay = () => {
-    playing = !playing;
+    project.togglePlay();
   };
+
   const handleToggleFollow = () => {
-    follow = !follow;
+    project.toggleFollow();
   };
 </script>
 
 <main class="min-h-screen bg-bg text-white flex flex-col">
-  <div class="flex-1 flex">
-    <!-- Transport rail -->
-    <Transport {playing} {follow}
+  <div class="flex-1 flex flex-col md:flex-row">
+    <Transport
+      class="md:w-48"
+      playing={$project.playing}
+      follow={$project.follow}
       on:toggleplay={handleTogglePlay}
       on:togglefollow={handleToggleFollow}
     />
     <div class="flex flex-col flex-1">
-      <TrackBar {tracks} selected={selectedTrack} on:select={handleSelect} />
-      <div class="flex-1 p-4">
-        <Grid rows={8} columns={16} {activeNotes} on:toggle={handleToggle} />
+      <TrackBar tracks={$project.tracks} selected={$project.selectedTrackIndex} on:select={handleSelect} />
+      <div class="flex-1 p-4 overflow-auto">
+        <Grid
+          rows={$project.rows}
+          columns={$project.columns}
+          activeNotes={$project.activeNotes}
+          on:toggle={handleToggle}
+        />
       </div>
-      <Footer bars={4} stepsPerBar={16} bpm={120} />
+      <Footer bars={$project.bars} stepsPerBar={$project.stepsPerBar} bpm={$project.bpm} />
     </div>
   </div>
 </main>
 
 <style>
-  main { background-color: var(--bg); }
+  :global(body) {
+    background-color: var(--bg);
+  }
 </style>

--- a/bitloops_app/src/app.css
+++ b/bitloops_app/src/app.css
@@ -1,0 +1,22 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  --bg: #0E1016;
+  --panel: #161A24;
+  --accent: #78D2B9;
+  --note-inactive: #3C4450;
+  color-scheme: dark;
+}
+
+body {
+  margin: 0;
+  background-color: var(--bg);
+  color: white;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+a {
+  color: inherit;
+}

--- a/bitloops_app/src/components/Grid.svelte
+++ b/bitloops_app/src/components/Grid.svelte
@@ -1,38 +1,59 @@
 <script>
-  // Props: activeNotes is a 2D boolean array
+  import { createEventDispatcher } from 'svelte';
+
   export let activeNotes = [];
   export let rows = 8;
   export let columns = 16;
-  /**
-   * Emit an event when a note is toggled
-   * @param {number} row
-   * @param {number} col
-   */
+
+  const dispatch = createEventDispatcher();
+
   const toggleNote = (row, col) => {
-    const event = new CustomEvent('toggle', { detail: { row, col } });
-    dispatchEvent(event);
+    dispatch('toggle', { row, col });
   };
 </script>
 
-<!--
-  This component will eventually render a canvas and handle hit testing.
-  For the stub, we show a simple grid of buttons.
--->
-<div class="grid" style="display: grid; grid-template-columns: repeat({columns}, 1fr); gap: 2px;">
-  {#each Array(rows) as _, row}
-    {#each Array(columns) as __, col}
+<div class="grid" style={`grid-template-columns: repeat(${columns}, minmax(0, 1fr));`}>
+  {#each Array.from({ length: rows }) as _, row}
+    {#each Array.from({ length: columns }) as __, col}
       <button
-        class="w-4 h-4 rounded-full border-0 focus:outline-none {activeNotes[row] && activeNotes[row][col] ? 'bg-accent' : 'bg-noteInactive'}"
+        class="cell"
+        class:bg-accent={activeNotes[row]?.[col]}
+        class:bg-noteInactive={!activeNotes[row]?.[col]}
         on:click={() => toggleNote(row, col)}
+        aria-pressed={activeNotes[row]?.[col] ? 'true' : 'false'}
       ></button>
     {/each}
   {/each}
 </div>
 
 <style>
+  .grid {
+    display: grid;
+    gap: 0.5rem;
+  }
+
+  .cell {
+    width: 1.5rem;
+    height: 1.5rem;
+    border-radius: 9999px;
+    border: none;
+    cursor: pointer;
+    transition: transform 0.1s ease;
+  }
+
+  .cell:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+  }
+
+  .cell:hover {
+    transform: scale(1.05);
+  }
+
   .bg-accent {
     background-color: var(--accent);
   }
+
   .bg-noteInactive {
     background-color: var(--note-inactive);
   }

--- a/bitloops_app/src/components/TrackBar.svelte
+++ b/bitloops_app/src/components/TrackBar.svelte
@@ -1,29 +1,66 @@
 <script>
+  import { createEventDispatcher } from 'svelte';
+
   export let tracks = [];
   export let selected = 0;
-  /**
-   * Select a track by index
-   * @param {number} idx
-   */
+
+  const dispatch = createEventDispatcher();
+
   const selectTrack = (idx) => {
-    const event = new CustomEvent('select', { detail: { index: idx } });
-    dispatchEvent(event);
+    dispatch('select', { index: idx });
   };
 </script>
 
-<div class="flex space-x-2 p-2 bg-panel">
+<div class="flex flex-wrap gap-2 p-2 bg-panel">
   {#each tracks as track, idx}
-    <div
-      class="flex items-center cursor-pointer px-3 py-1 rounded shadow-sm {idx === selected ? 'bg-accent' : 'bg-panel'}"
+    <button
+      type="button"
+      class="track"
+      class:track--active={idx === selected}
       on:click={() => selectTrack(idx)}
     >
-      <div class="w-2 h-4 mr-2 rounded" style="background-color: {track.color || 'var(--accent)'}"></div>
-      <span class="text-sm">{track.name}</span>
-    </div>
+      <span class="indicator" style={`background-color: ${track.color || 'var(--accent)'}`}></span>
+      <span class="label">{track.name}</span>
+    </button>
   {/each}
 </div>
 
 <style>
-  .bg-panel { background-color: var(--panel); }
-  .bg-accent { background-color: var(--accent); color: #0e1016; }
+  .track {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 0.75rem;
+    border-radius: 0.75rem;
+    background-color: var(--panel);
+    color: white;
+    border: 1px solid transparent;
+    cursor: pointer;
+    transition: transform 0.15s ease, background-color 0.15s ease;
+  }
+
+  .track:hover {
+    transform: translateY(-1px);
+  }
+
+  .track:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+  }
+
+  .track--active {
+    background-color: var(--accent);
+    color: #0e1016;
+  }
+
+  .indicator {
+    width: 0.35rem;
+    height: 1.5rem;
+    border-radius: 9999px;
+  }
+
+  .label {
+    font-size: 0.875rem;
+    font-weight: 500;
+  }
 </style>

--- a/bitloops_app/src/components/Transport.svelte
+++ b/bitloops_app/src/components/Transport.svelte
@@ -1,29 +1,61 @@
 <script>
+  import { createEventDispatcher } from 'svelte';
+
   export let playing = false;
   export let follow = false;
 
+  const dispatch = createEventDispatcher();
+
   const togglePlay = () => {
-    const event = new CustomEvent('toggleplay');
-    dispatchEvent(event);
+    dispatch('toggleplay');
   };
+
   const toggleFollow = () => {
-    const event = new CustomEvent('togglefollow');
-    dispatchEvent(event);
+    dispatch('togglefollow');
   };
 </script>
 
-<div class="flex flex-col items-center space-y-2 p-2 bg-panel">
-  <button class="bg-accent text-panel px-4 py-2 rounded" on:click={togglePlay}>
+<div class="transport bg-panel text-white p-4 flex md:flex-col gap-3 items-center md:items-stretch" {...$$restProps}>
+  <button class="btn btn--primary" type="button" on:click={togglePlay}>
     {playing ? 'Stop' : 'Play'}
   </button>
-  <button class="bg-panel text-accent border border-accent px-2 py-1 rounded" on:click={toggleFollow}>
+  <button class="btn btn--outline" type="button" on:click={toggleFollow}>
     {follow ? 'Following' : 'Free'}
   </button>
 </div>
 
 <style>
-  .bg-panel { background-color: var(--panel); }
-  .text-panel { color: var(--panel); }
-  .bg-accent { background-color: var(--accent); }
-  .text-accent { color: var(--accent); }
+  .transport {
+    min-width: 12rem;
+  }
+
+  .btn {
+    width: 100%;
+    padding: 0.75rem 1rem;
+    border-radius: 9999px;
+    font-weight: 600;
+    border: 1px solid transparent;
+    cursor: pointer;
+    transition: transform 0.15s ease, background-color 0.15s ease;
+  }
+
+  .btn:hover {
+    transform: translateY(-1px);
+  }
+
+  .btn:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 3px;
+  }
+
+  .btn--primary {
+    background-color: var(--accent);
+    color: #0e1016;
+  }
+
+  .btn--outline {
+    background-color: transparent;
+    border-color: var(--accent);
+    color: var(--accent);
+  }
 </style>

--- a/bitloops_app/src/main.js
+++ b/bitloops_app/src/main.js
@@ -1,7 +1,8 @@
 import App from './App.svelte';
+import './app.css';
 
 const app = new App({
-  target: document.getElementById('app'),
+  target: document.getElementById('app')
 });
 
 export default app;

--- a/bitloops_app/src/store/projectStore.js
+++ b/bitloops_app/src/store/projectStore.js
@@ -1,0 +1,95 @@
+import { derived, writable } from 'svelte/store';
+
+const createEmptyGrid = (rows, columns) =>
+  Array.from({ length: rows }, () => Array.from({ length: columns }, () => false));
+
+const defaultTracks = [
+  { name: 'Track 1', color: '#78D2B9', scale: 'minorPent', octave: 4, waveform: 'square', volume: 0.8, muted: false, solo: false },
+  { name: 'Track 2', color: '#A88EF6', scale: 'majorPent', octave: 4, waveform: 'triangle', volume: 0.8, muted: false, solo: false }
+];
+
+const initialConfig = {
+  bpm: 120,
+  bars: 4,
+  stepsPerBar: 16,
+  rows: 8,
+  columns: 16
+};
+
+const createProjectStore = () => {
+  const { rows, columns } = initialConfig;
+  const initialState = {
+    ...initialConfig,
+    tracks: defaultTracks,
+    selectedTrackIndex: 0,
+    playing: false,
+    follow: false,
+    activeNotes: createEmptyGrid(rows, columns)
+  };
+
+  const { subscribe, update, set } = writable(initialState);
+
+  return {
+    subscribe,
+    reset: () => {
+      set({
+        ...initialState,
+        activeNotes: createEmptyGrid(initialState.rows, initialState.columns)
+      });
+    },
+    toggleNote: (row, column) => {
+      update((state) => {
+        if (row < 0 || row >= state.rows || column < 0 || column >= state.columns) {
+          return state;
+        }
+
+        const nextGrid = state.activeNotes.map((r, rIdx) =>
+          rIdx === row
+            ? r.map((value, cIdx) => (cIdx === column ? !value : value))
+            : r.slice()
+        );
+
+        return { ...state, activeNotes: nextGrid };
+      });
+    },
+    selectTrack: (index) => {
+      update((state) => {
+        const bounded = Math.max(0, Math.min(index, state.tracks.length - 1));
+        return { ...state, selectedTrackIndex: bounded };
+      });
+    },
+    togglePlay: () => {
+      update((state) => ({ ...state, playing: !state.playing }));
+    },
+    toggleFollow: () => {
+      update((state) => ({ ...state, follow: !state.follow }));
+    },
+    setTempo: (bpm) => {
+      update((state) => ({ ...state, bpm }));
+    },
+    setBars: (bars) => {
+      update((state) => ({ ...state, bars }));
+    },
+    setStepsPerBar: (stepsPerBar) => {
+      update((state) => ({ ...state, stepsPerBar }));
+    },
+    updateTrack: (index, data) => {
+      update((state) => {
+        if (index < 0 || index >= state.tracks.length) {
+          return state;
+        }
+        const tracks = state.tracks.map((track, idx) =>
+          idx === index ? { ...track, ...data } : track
+        );
+        return { ...state, tracks };
+      });
+    }
+  };
+};
+
+export const project = createProjectStore();
+
+export const loopSeconds = derived(project, ($project) => {
+  const { bpm, bars, stepsPerBar } = $project;
+  return (60 / bpm) * (stepsPerBar / 4) * bars;
+});

--- a/bitloops_app/svelte.config.js
+++ b/bitloops_app/svelte.config.js
@@ -1,0 +1,7 @@
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
+
+const config = {
+  preprocess: vitePreprocess(),
+};
+
+export default config;

--- a/bitloops_app/tailwind.config.cjs
+++ b/bitloops_app/tailwind.config.cjs
@@ -1,0 +1,14 @@
+module.exports = {
+  content: ['./index.html', './src/**/*.{svelte,js,ts}'],
+  theme: {
+    extend: {
+      colors: {
+        bg: '#0E1016',
+        panel: '#161A24',
+        accent: '#78D2B9',
+        noteInactive: '#3C4450'
+      }
+    }
+  },
+  plugins: []
+};

--- a/bitloops_app/vite.config.js
+++ b/bitloops_app/vite.config.js
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vite';
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+import path from 'node:path';
+
+export default defineConfig({
+  plugins: [svelte()],
+  resolve: {
+    alias: {
+      $components: path.resolve('./src/components'),
+      $store: path.resolve('./src/store'),
+      $lib: path.resolve('./src/lib')
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- restore the BitLoops Svelte sources under `bitloops_app/src` and wire them to a central project store
- add the missing Vite, Tailwind, and PostCSS configuration plus npm metadata for the app bundle
- fix component event dispatching and styles so the UI works with the reinstated store-driven data

## Testing
- `npm install` *(fails: 403 Forbidden from registry.npmjs.org)*
- `npm run dev -- --host 0.0.0.0 --port 4173` *(fails: vite not found because install could not complete)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fcb3d67748326b36261b16b32ddb8)