### PR TITLE
Add project autosave, library management, and offline rendering

### DIFF
--- a/bitloops_app/src/components/Footer.svelte
+++ b/bitloops_app/src/components/Footer.svelte
@@ -1,14 +1,21 @@
 <script>
   import { createEventDispatcher } from 'svelte';
 
+  export let name = 'Untitled loop';
   export let bars = 4;
   export let stepsPerBar = 16;
   export let bpm = 120;
   export let loopSeconds = 0;
   export let maxBars = 64;
+  export let canUndo = false;
+  export let canRedo = false;
+  export let projects = [];
+  export let currentId = null;
+  export let isSaving = false;
 
   const dispatch = createEventDispatcher();
   let fileInput;
+  let selectedProjectId = currentId ?? '';
 
   const handleBarsChange = (event) => {
     const value = Number(event.target.value);
@@ -38,67 +45,110 @@
       event.target.value = '';
     }
   };
+
+  const handleUndo = () => dispatch('undo');
+  const handleRedo = () => dispatch('redo');
+  const handleRename = (event) => dispatch('renameproject', { value: event.target.value });
+  const handleSelectProject = (event) => dispatch('selectproject', { id: event.target.value });
+  const handleNewProject = () => dispatch('newproject');
+  const handleDuplicateProject = () => dispatch('duplicateproject');
+  const handleDeleteProject = () => dispatch('deleteproject');
+  const handleRender = () => dispatch('render');
+
+  $: selectedProjectId = currentId ?? '';
 </script>
 
 <footer class="footer">
-  <div class="timing">
-    <div class="field">
-      <label for="bars">Bars</label>
-      <div class="input-shell">
-        <input
-          id="bars"
-          type="number"
-          min="1"
-          max={maxBars}
-          value={bars}
-          on:change={handleBarsChange}
-        />
-        <span class="hint">Max {maxBars}</span>
+  <div class="project-column">
+    <div class="field name-field">
+      <label for="project-name">Project name</label>
+      <input id="project-name" type="text" value={name} on:change={handleRename} />
+      <span class={`status ${isSaving ? 'saving' : ''}`}>{isSaving ? 'Saving…' : 'Saved'}</span>
+    </div>
+    <div class="field session-field">
+      <label for="project-select">Sessions</label>
+      <div class="select-shell">
+        <select id="project-select" bind:value={selectedProjectId} on:change={handleSelectProject}>
+          {#if !projects.length}
+            <option value="" disabled>No saved sessions</option>
+          {:else}
+            {#each projects as option}
+              <option value={option.id}>{option.name}</option>
+            {/each}
+          {/if}
+        </select>
+      </div>
+      <div class="library-actions">
+        <button type="button" on:click={handleNewProject}>New</button>
+        <button type="button" on:click={handleDuplicateProject} disabled={!selectedProjectId}>Duplicate</button>
+        <button type="button" on:click={handleDeleteProject} disabled={projects.length <= 1}>Delete</button>
       </div>
     </div>
-    <div class="field">
-      <label for="steps">Steps / bar</label>
-      <div class="input-shell">
-        <input
-          id="steps"
-          type="number"
-          min="4"
-          max="64"
-          step="1"
-          value={stepsPerBar}
-          on:change={handleStepsChange}
-        />
-      </div>
-    </div>
-    <div class="loop-card">
-      <span class="loop-label">Loop</span>
-      <span class="loop-value">{loopSeconds.toFixed(1)} s</span>
-      <span class="loop-sub">{bpm} BPM</span>
+    <div class="history-actions">
+      <button type="button" on:click={handleUndo} disabled={!canUndo}>Undo</button>
+      <button type="button" on:click={handleRedo} disabled={!canRedo}>Redo</button>
     </div>
   </div>
-  <div class="actions">
-    <button class="ghost" type="button" on:click={handleExport}>Export project</button>
-    <button class="primary" type="button" on:click={handleImportClick}>Import</button>
+  <div class="timeline-column">
+    <div class="timing">
+      <div class="field">
+        <label for="bars">Bars</label>
+        <div class="input-shell">
+          <input
+            id="bars"
+            type="number"
+            min="1"
+            max={maxBars}
+            value={bars}
+            on:change={handleBarsChange}
+          />
+          <span class="hint">Max {maxBars}</span>
+        </div>
+      </div>
+      <div class="field">
+        <label for="steps">Steps / bar</label>
+        <div class="input-shell">
+          <input
+            id="steps"
+            type="number"
+            min="4"
+            max="64"
+            step="1"
+            value={stepsPerBar}
+            on:change={handleStepsChange}
+          />
+        </div>
+      </div>
+      <div class="loop-card">
+        <span class="loop-label">Loop</span>
+        <span class="loop-value">{loopSeconds.toFixed(1)} s</span>
+        <span class="loop-sub">{bpm} BPM</span>
+      </div>
+    </div>
+  </div>
+  <div class="action-column">
+    <button class="primary" type="button" on:click={handleRender}>Render WAV</button>
+    <button class="ghost" type="button" on:click={handleExport}>Export JSON</button>
+    <button class="ghost" type="button" on:click={handleImportClick}>Import</button>
     <input type="file" accept=".json,.bitloops.json" bind:this={fileInput} on:change={handleImport} hidden />
   </div>
 </footer>
 
 <style>
   .footer {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 20px 32px 28px;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
     gap: 24px;
-    flex-wrap: wrap;
+    padding: 24px 32px 32px;
     color: rgba(255, 255, 255, 0.85);
   }
 
-  .timing {
+  .project-column,
+  .timeline-column,
+  .action-column {
     display: flex;
-    align-items: center;
-    gap: 24px;
-    flex-wrap: wrap;
+    flex-direction: column;
+    gap: 18px;
   }
 
   .field {
@@ -112,6 +162,86 @@
 
   .field label {
     color: rgba(255, 255, 255, 0.58);
+  }
+
+  .name-field input {
+    background: rgba(0, 0, 0, 0.35);
+    border-radius: 12px;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    padding: 10px 14px;
+    color: #fff;
+    font-size: 1rem;
+  }
+
+  .name-field input:focus {
+    outline: 2px solid rgba(var(--color-accent-rgb), 0.5);
+    outline-offset: 2px;
+  }
+
+  .status {
+    font-size: 0.7rem;
+    letter-spacing: 0.08em;
+    color: rgba(255, 255, 255, 0.5);
+  }
+
+  .status.saving {
+    color: rgba(var(--color-accent-rgb), 0.85);
+  }
+
+  .select-shell select {
+    width: 100%;
+    background: rgba(0, 0, 0, 0.35);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 12px;
+    padding: 10px 14px;
+    color: #fff;
+    font-size: 0.95rem;
+  }
+
+  .library-actions {
+    display: flex;
+    gap: 8px;
+  }
+
+  .library-actions button,
+  .history-actions button,
+  .action-column button {
+    padding: 12px 16px;
+    border-radius: 12px;
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    background: rgba(0, 0, 0, 0.3);
+    color: #fff;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    font-size: 0.75rem;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, border 0.2s ease;
+  }
+
+  .library-actions button:hover,
+  .history-actions button:hover,
+  .action-column button:hover {
+    transform: translateY(-2px);
+    border-color: rgba(var(--color-accent-rgb), 0.5);
+  }
+
+  .library-actions button:disabled,
+  .history-actions button:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+    transform: none;
+  }
+
+  .history-actions {
+    display: flex;
+    gap: 12px;
+  }
+
+  .timing {
+    display: flex;
+    align-items: center;
+    gap: 24px;
+    flex-wrap: wrap;
   }
 
   .input-shell {
@@ -176,36 +306,35 @@
     letter-spacing: 0.12em;
   }
 
-  .actions {
-    display: flex;
-    gap: 12px;
-    flex-wrap: wrap;
+  .action-column {
+    align-items: flex-start;
   }
 
-  .actions button {
-    padding: 12px 18px;
-    border-radius: 14px;
-    font-size: 0.85rem;
-    letter-spacing: 0.1em;
-    text-transform: uppercase;
-    cursor: pointer;
-    transition: transform 0.2s ease, box-shadow 0.2s ease;
-  }
-
-  .actions button:hover {
-    transform: translateY(-2px);
+  .primary {
+    border: 1px solid rgba(var(--color-accent-rgb), 0.7);
+    background: rgba(var(--color-accent-rgb), 0.28);
+    box-shadow: 0 18px 42px rgba(var(--color-accent-rgb), 0.35);
   }
 
   .ghost {
     border: 1px solid rgba(255, 255, 255, 0.25);
     background: rgba(255, 255, 255, 0.05);
-    color: #fff;
   }
 
-  .primary {
-    border: 1px solid rgba(var(--color-accent-rgb), 0.6);
-    background: rgba(var(--color-accent-rgb), 0.22);
-    color: #fff;
-    box-shadow: 0 16px 40px rgba(var(--color-accent-rgb), 0.3);
+  @media (max-width: 720px) {
+    .project-column {
+      order: 1;
+    }
+
+    .timeline-column {
+      order: 2;
+    }
+
+    .action-column {
+      order: 3;
+      flex-direction: row;
+      flex-wrap: wrap;
+      gap: 12px;
+    }
   }
 </style>

--- a/bitloops_app/src/components/TrackBar.svelte
+++ b/bitloops_app/src/components/TrackBar.svelte
@@ -4,6 +4,10 @@
 
   export let tracks = [];
   export let selected = 0;
+  export let maxTracks = 10;
+
+  const canAddMore = () => tracks.length < maxTracks;
+  const canRemoveTrack = (index) => tracks.length > 1 && index >= 0 && index < tracks.length;
 
   const dispatch = createEventDispatcher();
 
@@ -12,6 +16,17 @@
 
   const handleSelect = (idx) => {
     dispatch('select', { index: idx });
+  };
+
+  const handleAddTrack = () => {
+    if (!canAddMore()) return;
+    dispatch('add');
+  };
+
+  const handleRemoveTrack = (event, idx) => {
+    event.stopPropagation();
+    if (!canRemoveTrack(idx)) return;
+    dispatch('remove', { index: idx });
   };
 
   const handleChange = (key, value) => {
@@ -38,12 +53,47 @@
           <span class="chip-name">{track.name}</span>
           <span class="chip-meta">{track.waveform} • {track.scale}</span>
         </span>
+        {#if canRemoveTrack(idx)}
+          <span class="chip-actions">
+            <button
+              type="button"
+              class="chip-remove"
+              aria-label={`Remove ${track.name}`}
+              on:click={(event) => handleRemoveTrack(event, idx)}
+            >
+              ×
+            </button>
+          </span>
+        {/if}
       </button>
     {/each}
+    <button
+      class="track-chip add"
+      type="button"
+      on:click={handleAddTrack}
+      disabled={!canAddMore()}
+      aria-label="Add track"
+    >
+      <span class="chip-strip" aria-hidden="true">+</span>
+      <span class="chip-content">
+        <span class="chip-name">Add track</span>
+        <span class="chip-meta">{tracks.length}/{maxTracks}</span>
+      </span>
+    </button>
   </div>
 
   {#if tracks && tracks[selected]}
     <div class="control-panel">
+      <div class="control">
+        <label for="track-name">Track name</label>
+        <input
+          id="track-name"
+          type="text"
+          value={tracks[selected].name}
+          on:change={(event) => handleChange('name', event.target.value)}
+        />
+      </div>
+
       <div class="control">
         <label for="waveform">Waveform</label>
         <select
@@ -82,6 +132,16 @@
             on:change={(event) => handleChange('octave', Number(event.target.value))}
           />
         </div>
+      </div>
+
+      <div class="control">
+        <label for="track-color">Track color</label>
+        <input
+          id="track-color"
+          type="color"
+          value={tracks[selected].color}
+          on:input={(event) => handleChange('color', event.target.value)}
+        />
       </div>
 
       <div class="control volume">
@@ -147,7 +207,7 @@
 
   .track-chip {
     display: grid;
-    grid-template-columns: 12px 1fr;
+    grid-template-columns: 12px 1fr auto;
     align-items: center;
     padding: 12px 16px;
     border-radius: 16px;
@@ -176,12 +236,56 @@
     width: 12px;
     height: 100%;
     border-radius: 999px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 700;
   }
 
   .chip-content {
     display: flex;
     flex-direction: column;
     gap: 4px;
+  }
+
+  .chip-actions {
+    display: flex;
+    align-items: center;
+  }
+
+  .chip-remove {
+    background: rgba(255, 255, 255, 0.08);
+    border: none;
+    color: rgba(255, 255, 255, 0.8);
+    border-radius: 50%;
+    width: 28px;
+    height: 28px;
+    cursor: pointer;
+    font-size: 1.1rem;
+    line-height: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: background 0.2s ease, color 0.2s ease;
+  }
+
+  .chip-remove:hover,
+  .chip-remove:focus {
+    background: rgba(255, 80, 80, 0.25);
+    color: #fff;
+    outline: none;
+  }
+
+  .track-chip.add {
+    border-style: dashed;
+    border-color: rgba(255, 255, 255, 0.2);
+    background: rgba(17, 20, 29, 0.6);
+    min-width: 120px;
+  }
+
+  .track-chip.add:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
   }
 
   .chip-name {
@@ -224,7 +328,8 @@
 
   select,
   input[type='number'],
-  input[type='range'] {
+  input[type='range'],
+  input[type='text'] {
     background: rgba(0, 0, 0, 0.35);
     color: #fff;
     border-radius: 12px;
@@ -235,9 +340,20 @@
 
   select:focus,
   input[type='number']:focus,
-  input[type='range']:focus {
+  input[type='range']:focus,
+  input[type='text']:focus {
     outline: 2px solid rgba(var(--color-accent-rgb), 0.5);
     outline-offset: 2px;
+  }
+
+  input[type='color'] {
+    width: 48px;
+    height: 36px;
+    border: none;
+    border-radius: 12px;
+    padding: 0;
+    background: none;
+    cursor: pointer;
   }
 
   .number-field input {

--- a/bitloops_app/src/lib/persistence.js
+++ b/bitloops_app/src/lib/persistence.js
@@ -1,0 +1,193 @@
+const DB_NAME = 'bitloops-workspace';
+const DB_VERSION = 1;
+const PROJECT_STORE = 'projects';
+const META_STORE = 'meta';
+const CURRENT_PROJECT_KEY = 'currentProjectId';
+const DEFAULT_NAME = 'Untitled loop';
+
+const isBrowser = typeof window !== 'undefined' && typeof window.indexedDB !== 'undefined';
+
+let dbPromise;
+const memoryStore = {
+  projects: new Map(),
+  meta: new Map()
+};
+
+const generateId = () => {
+  if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+    return crypto.randomUUID();
+  }
+  return `proj-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+};
+
+const ensureName = (name) => {
+  const trimmed = typeof name === 'string' ? name.trim() : '';
+  return trimmed.length ? trimmed : DEFAULT_NAME;
+};
+
+const requestPromise = (request) =>
+  new Promise((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+
+const openDatabase = () => {
+  if (!isBrowser) return null;
+  if (!dbPromise) {
+    dbPromise = new Promise((resolve, reject) => {
+      const request = indexedDB.open(DB_NAME, DB_VERSION);
+      request.onupgradeneeded = () => {
+        const db = request.result;
+        let projectStore;
+        if (!db.objectStoreNames.contains(PROJECT_STORE)) {
+          projectStore = db.createObjectStore(PROJECT_STORE, { keyPath: 'id' });
+        } else {
+          projectStore = request.transaction.objectStore(PROJECT_STORE);
+        }
+        if (!projectStore.indexNames.contains('by-updated')) {
+          projectStore.createIndex('by-updated', 'updatedAt', { unique: false });
+        }
+        if (!db.objectStoreNames.contains(META_STORE)) {
+          db.createObjectStore(META_STORE);
+        }
+      };
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(request.error);
+    });
+  }
+  return dbPromise;
+};
+
+const mapRecord = (record) => ({
+  id: record.id,
+  name: record.name ?? DEFAULT_NAME,
+  createdAt: record.createdAt,
+  updatedAt: record.updatedAt
+});
+
+const listMemoryProjects = () =>
+  Array.from(memoryStore.projects.values())
+    .map(mapRecord)
+    .sort((a, b) => b.updatedAt - a.updatedAt);
+
+export const listProjects = async () => {
+  if (!isBrowser) {
+    return listMemoryProjects();
+  }
+  const db = await openDatabase();
+  const tx = db.transaction(PROJECT_STORE, 'readonly');
+  const store = tx.objectStore(PROJECT_STORE);
+  const index = store.index('by-updated');
+  const records = await requestPromise(index.getAll());
+  return records.sort((a, b) => b.updatedAt - a.updatedAt).map(mapRecord);
+};
+
+export const loadProject = async (id) => {
+  if (!id) return null;
+  if (!isBrowser) {
+    return memoryStore.projects.get(id) ?? null;
+  }
+  const db = await openDatabase();
+  const tx = db.transaction(PROJECT_STORE, 'readonly');
+  const store = tx.objectStore(PROJECT_STORE);
+  return requestPromise(store.get(id));
+};
+
+const putRecord = async (record) => {
+  if (!isBrowser) {
+    memoryStore.projects.set(record.id, record);
+    return mapRecord(record);
+  }
+  const db = await openDatabase();
+  const tx = db.transaction(PROJECT_STORE, 'readwrite');
+  const store = tx.objectStore(PROJECT_STORE);
+  await requestPromise(store.put(record));
+  return mapRecord(record);
+};
+
+export const createProject = async ({ name = DEFAULT_NAME, data = null } = {}) => {
+  const timestamp = Date.now();
+  const record = {
+    id: generateId(),
+    name: ensureName(name),
+    createdAt: timestamp,
+    updatedAt: timestamp,
+    data
+  };
+  return putRecord(record);
+};
+
+export const saveProjectData = async (id, data, { name } = {}) => {
+  if (!id) return null;
+  const existing = await loadProject(id);
+  const timestamp = Date.now();
+  const record = {
+    id,
+    name: ensureName(name ?? existing?.name ?? DEFAULT_NAME),
+    createdAt: existing?.createdAt ?? timestamp,
+    updatedAt: timestamp,
+    data
+  };
+  return putRecord(record);
+};
+
+export const renameProject = async (id, name) => {
+  if (!id) return null;
+  const existing = await loadProject(id);
+  if (!existing) return null;
+  return putRecord({ ...existing, name: ensureName(name), updatedAt: Date.now() });
+};
+
+export const duplicateProject = async (id) => {
+  const existing = await loadProject(id);
+  const baseName = existing?.name ?? DEFAULT_NAME;
+  return createProject({ name: `${baseName} copy`, data: existing?.data ?? null });
+};
+
+export const deleteProject = async (id) => {
+  if (!id) return;
+  if (!isBrowser) {
+    memoryStore.projects.delete(id);
+    return;
+  }
+  const db = await openDatabase();
+  const tx = db.transaction(PROJECT_STORE, 'readwrite');
+  const store = tx.objectStore(PROJECT_STORE);
+  await requestPromise(store.delete(id));
+};
+
+export const getCurrentProjectId = async () => {
+  if (!isBrowser) {
+    return memoryStore.meta.get(CURRENT_PROJECT_KEY) ?? null;
+  }
+  const db = await openDatabase();
+  const tx = db.transaction(META_STORE, 'readonly');
+  const store = tx.objectStore(META_STORE);
+  return requestPromise(store.get(CURRENT_PROJECT_KEY));
+};
+
+export const setCurrentProjectId = async (id) => {
+  if (!isBrowser) {
+    memoryStore.meta.set(CURRENT_PROJECT_KEY, id);
+    return;
+  }
+  const db = await openDatabase();
+  const tx = db.transaction(META_STORE, 'readwrite');
+  const store = tx.objectStore(META_STORE);
+  await requestPromise(store.put(id, CURRENT_PROJECT_KEY));
+};
+
+export const resetAll = async () => {
+  if (!isBrowser) {
+    memoryStore.projects.clear();
+    memoryStore.meta.clear();
+    return;
+  }
+  const db = await openDatabase();
+  const tx = db.transaction([PROJECT_STORE, META_STORE], 'readwrite');
+  await Promise.all([
+    requestPromise(tx.objectStore(PROJECT_STORE).clear()),
+    requestPromise(tx.objectStore(META_STORE).clear())
+  ]);
+};
+

--- a/bitloops_app/src/store/libraryStore.js
+++ b/bitloops_app/src/store/libraryStore.js
@@ -1,0 +1,151 @@
+import { writable, get } from 'svelte/store';
+import {
+  listProjects,
+  createProject,
+  duplicateProject,
+  deleteProject,
+  renameProject as renameProjectRecord,
+  loadProject,
+  saveProjectData,
+  getCurrentProjectId,
+  setCurrentProjectId
+} from '../lib/persistence.js';
+import { project } from './projectStore.js';
+
+const AUTOSAVE_DEBOUNCE = 600;
+
+const createLibraryStore = () => {
+  const store = writable({
+    projects: [],
+    currentId: null,
+    loading: true,
+    status: 'idle'
+  });
+
+  const { subscribe, set, update } = store;
+
+  let autosaveTimer = null;
+  let lastSnapshotHash = '';
+  let initialized = false;
+  let unsubscribeProject = null;
+
+  const computeHash = (snapshot) => JSON.stringify(snapshot);
+
+  const refreshProjects = async (currentId) => {
+    const projects = await listProjects();
+    update((state) => ({ ...state, projects, currentId: currentId ?? state.currentId }));
+  };
+
+  const loadIntoStore = async (projectId) => {
+    if (!projectId) return false;
+    const record = await loadProject(projectId);
+    if (record?.data) {
+      const loaded = project.load(record.data);
+      if (!loaded) return false;
+    }
+    project.setName(record?.name ?? 'Untitled loop');
+    await setCurrentProjectId(projectId);
+    update((state) => ({ ...state, currentId: projectId }));
+    return true;
+  };
+
+  const queueAutosave = (snapshot) => {
+    if (!snapshot) return;
+    const projectId = get(store).currentId;
+    if (!projectId) return;
+    const signature = computeHash(snapshot);
+    if (signature === lastSnapshotHash) return;
+    lastSnapshotHash = signature;
+    if (autosaveTimer) clearTimeout(autosaveTimer);
+    autosaveTimer = setTimeout(async () => {
+      update((state) => ({ ...state, status: 'saving' }));
+      await saveProjectData(projectId, snapshot, { name: snapshot.name });
+      await refreshProjects(projectId);
+      update((state) => ({ ...state, status: 'idle' }));
+    }, AUTOSAVE_DEBOUNCE);
+  };
+
+  const subscribeToProject = () => {
+    unsubscribeProject?.();
+    unsubscribeProject = project.subscribe((value) => {
+      if (!initialized) return;
+      if (value?.playing) return;
+      const snapshot = project.toSnapshot();
+      queueAutosave(snapshot);
+    });
+  };
+
+  return {
+    subscribe,
+    async initialize() {
+      if (initialized) return;
+      initialized = true;
+      set((state) => ({ ...state, loading: true }));
+      subscribeToProject();
+      let currentId = await getCurrentProjectId();
+      await refreshProjects(currentId);
+      const currentState = get(store);
+      if (!currentId && currentState.projects.length > 0) {
+        currentId = currentState.projects[0].id;
+      }
+      if (!currentId) {
+        const created = await createProject({ name: project.getName(), data: project.toSnapshot() });
+        currentId = created.id;
+      }
+      await loadIntoStore(currentId);
+      await refreshProjects(currentId);
+      set((state) => ({ ...state, loading: false }));
+    },
+    async selectProject(id) {
+      if (!id) return;
+      await loadIntoStore(id);
+      await refreshProjects(id);
+    },
+    async createNew() {
+      const snapshot = project.defaultSnapshot();
+      const created = await createProject({ name: snapshot.name, data: snapshot });
+      await loadIntoStore(created.id);
+      await refreshProjects(created.id);
+    },
+    async duplicateCurrent() {
+      const currentId = get(store).currentId;
+      if (!currentId) return;
+      const duplicated = await duplicateProject(currentId);
+      const record = await loadProject(currentId);
+      if (record?.data) {
+        await saveProjectData(duplicated.id, record.data, { name: duplicated.name });
+      }
+      await loadIntoStore(duplicated.id);
+      await refreshProjects(duplicated.id);
+    },
+    async deleteCurrent() {
+      const state = get(store);
+      if (!state.currentId || state.projects.length <= 1) return;
+      const index = state.projects.findIndex((p) => p.id === state.currentId);
+      await deleteProject(state.currentId);
+      const next = state.projects[index + 1] ?? state.projects[index - 1];
+      await refreshProjects(next?.id);
+      await loadIntoStore(next?.id);
+    },
+    async renameCurrent(name) {
+      const state = get(store);
+      if (!state.currentId) return;
+      await renameProjectRecord(state.currentId, name);
+      project.setName(name);
+      await refreshProjects(state.currentId);
+    },
+    dispose() {
+      unsubscribeProject?.();
+      unsubscribeProject = null;
+      if (autosaveTimer) {
+        clearTimeout(autosaveTimer);
+        autosaveTimer = null;
+      }
+      initialized = false;
+      lastSnapshotHash = '';
+    }
+  };
+};
+
+export const library = createLibraryStore();
+


### PR DESCRIPTION
## Summary
- add a persistence layer with IndexedDB fallback for autosaving and managing sequencer projects
- extend the project store with undo/redo history, track management APIs, and project naming metadata
- refresh the UI with project library controls, enhanced track editor tools, and offline WAV rendering support

## Testing
- npm run test:run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69100b9d1d34832686babc9f7d7fcddc)