### PR TITLE
Add share links and per-track sound design upgrades

### DIFF
--- a/bitloops_app/src/components/Footer.svelte
+++ b/bitloops_app/src/components/Footer.svelte
@@ -12,6 +12,9 @@
   export let projects = [];
   export let currentId = null;
   export let isSaving = false;
+  export let shareStatus = 'idle';
+  export let shareMessage = '';
+  export let shareLink = '';
 
   const dispatch = createEventDispatcher();
   let fileInput;
@@ -54,6 +57,7 @@
   const handleDuplicateProject = () => dispatch('duplicateproject');
   const handleDeleteProject = () => dispatch('deleteproject');
   const handleRender = () => dispatch('render');
+  const handleShare = () => dispatch('share');
 
   $: selectedProjectId = currentId ?? '';
 </script>
@@ -127,9 +131,28 @@
     </div>
   </div>
   <div class="action-column">
-    <button class="primary" type="button" on:click={handleRender}>Render WAV</button>
-    <button class="ghost" type="button" on:click={handleExport}>Export JSON</button>
-    <button class="ghost" type="button" on:click={handleImportClick}>Import</button>
+    <div class="primary-actions">
+      <button class="primary" type="button" on:click={handleRender}>Render WAV</button>
+      <button class="secondary" type="button" on:click={handleShare}>Share loop</button>
+    </div>
+    {#if shareStatus !== 'idle'}
+      <div class={`share-feedback ${shareStatus}`}>
+        <span>{shareMessage}</span>
+        {#if shareLink}
+          <input
+            class="share-link"
+            type="text"
+            readonly
+            value={shareLink}
+            on:focus={(event) => event.target.select()}
+          />
+        {/if}
+      </div>
+    {/if}
+    <div class="export-actions">
+      <button class="ghost" type="button" on:click={handleExport}>Export JSON</button>
+      <button class="ghost" type="button" on:click={handleImportClick}>Import</button>
+    </div>
     <input type="file" accept=".json,.bitloops.json" bind:this={fileInput} on:change={handleImport} hidden />
   </div>
 </footer>
@@ -307,7 +330,15 @@
   }
 
   .action-column {
-    align-items: flex-start;
+    align-items: stretch;
+    gap: 16px;
+  }
+
+  .primary-actions,
+  .export-actions {
+    display: flex;
+    gap: 12px;
+    flex-wrap: wrap;
   }
 
   .primary {
@@ -316,9 +347,56 @@
     box-shadow: 0 18px 42px rgba(var(--color-accent-rgb), 0.35);
   }
 
+  .secondary {
+    border: 1px solid rgba(var(--color-note-active-rgb), 0.55);
+    background: rgba(var(--color-note-active-rgb), 0.18);
+    box-shadow: 0 14px 32px rgba(var(--color-note-active-rgb), 0.3);
+  }
+
   .ghost {
     border: 1px solid rgba(255, 255, 255, 0.25);
     background: rgba(255, 255, 255, 0.05);
+  }
+
+  .share-feedback {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    font-size: 0.72rem;
+    letter-spacing: 0.08em;
+    color: rgba(255, 255, 255, 0.7);
+    padding: 12px 14px;
+    border-radius: 12px;
+    background: rgba(0, 0, 0, 0.38);
+    border: 1px solid rgba(255, 255, 255, 0.14);
+  }
+
+  .share-feedback.copied,
+  .share-feedback.shared,
+  .share-feedback.loaded {
+    border-color: rgba(var(--color-accent-rgb), 0.5);
+    color: #fff;
+  }
+
+  .share-feedback.error {
+    border-color: rgba(255, 99, 132, 0.7);
+    color: rgba(255, 199, 206, 0.95);
+  }
+
+  .share-link {
+    width: 100%;
+    background: rgba(0, 0, 0, 0.5);
+    border: 1px solid rgba(255, 255, 255, 0.18);
+    border-radius: 10px;
+    padding: 8px 10px;
+    color: #fff;
+    font-size: 0.75rem;
+    letter-spacing: 0.04em;
+  }
+
+  .share-link:focus {
+    outline: 2px solid rgba(var(--color-accent-rgb), 0.4);
+    outline-offset: 2px;
   }
 
   @media (max-width: 720px) {
@@ -332,9 +410,13 @@
 
     .action-column {
       order: 3;
-      flex-direction: row;
-      flex-wrap: wrap;
-      gap: 12px;
+      flex-direction: column;
+      gap: 16px;
+    }
+
+    .primary-actions,
+    .export-actions {
+      width: 100%;
     }
   }
 </style>

--- a/bitloops_app/src/lib/sound.js
+++ b/bitloops_app/src/lib/sound.js
@@ -1,0 +1,142 @@
+const contextWaveCache = new WeakMap();
+
+const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
+
+const getCacheForContext = (context) => {
+  if (!contextWaveCache.has(context)) {
+    contextWaveCache.set(context, new Map());
+  }
+  return contextWaveCache.get(context);
+};
+
+export const getCustomWave = (context, shape = 0.5) => {
+  if (!context?.createPeriodicWave) return null;
+  const normalized = clamp(Number.isFinite(shape) ? shape : parseFloat(shape) || 0.5, 0, 1);
+  const key = normalized.toFixed(2);
+  const cache = getCacheForContext(context);
+  if (cache.has(key)) {
+    return cache.get(key);
+  }
+
+  const harmonics = 12;
+  const real = new Float32Array(harmonics + 1);
+  const imag = new Float32Array(harmonics + 1);
+
+  for (let i = 1; i <= harmonics; i += 1) {
+    const sineComponent = (1 - normalized) * (1 / i);
+    const sawComponent = normalized * (1 / i);
+    const squareComponent = normalized * (i % 2 ? 1 / i : 0);
+    real[i] = squareComponent;
+    imag[i] = sineComponent + sawComponent;
+  }
+
+  const periodicWave = context.createPeriodicWave(real, imag, { disableNormalization: false });
+  cache.set(key, periodicWave);
+  return periodicWave;
+};
+
+export const connectTrackEffects = (context, track, sourceNode, destinationNode, startTime = context?.currentTime ?? 0) => {
+  if (!context || !sourceNode || !destinationNode) return;
+  const effects = track?.effects ?? {};
+  let currentNode = sourceNode;
+
+  if (effects.filterType && effects.filterType !== 'none') {
+    const filter = context.createBiquadFilter();
+    filter.type = effects.filterType;
+    filter.frequency.setValueAtTime(effects.filterCutoff ?? 1800, startTime);
+    filter.Q.setValueAtTime(effects.filterQ ?? 0.7, startTime);
+    currentNode.connect(filter);
+    currentNode = filter;
+  }
+
+  const mix = clamp(effects.delayMix ?? 0, 0, 0.9);
+  if (mix > 0) {
+    const dryGain = context.createGain();
+    dryGain.gain.setValueAtTime(1 - mix, startTime);
+    currentNode.connect(dryGain);
+    dryGain.connect(destinationNode);
+
+    const delayNode = context.createDelay(1);
+    delayNode.delayTime.setValueAtTime(clamp(effects.delayTime ?? 0.25, 0.05, 0.8), startTime);
+    const feedbackGain = context.createGain();
+    feedbackGain.gain.setValueAtTime(clamp(effects.delayFeedback ?? 0.3, 0, 0.9), startTime);
+    const wetGain = context.createGain();
+    wetGain.gain.setValueAtTime(mix, startTime);
+
+    currentNode.connect(delayNode);
+    delayNode.connect(wetGain);
+    wetGain.connect(destinationNode);
+    delayNode.connect(feedbackGain);
+    feedbackGain.connect(delayNode);
+    return;
+  }
+
+  currentNode.connect(destinationNode);
+};
+
+export const getTrackDisplayWaveform = (track) => {
+  if (!track) return 'unknown';
+  if (track.waveform !== 'custom') return track.waveform;
+  const intensity = Math.round(clamp(track.customShape ?? 0.5, 0, 1) * 100);
+  return `custom ${intensity}%`;
+};
+
+export const SHARE_TEXT = 'Check out my BitLoops loop!';
+
+export const encodeShareSnapshot = (snapshot) => {
+  if (!snapshot) return '';
+  const json = JSON.stringify(snapshot);
+  if (typeof window === 'undefined' && typeof Buffer !== 'undefined') {
+    return Buffer.from(json, 'utf-8').toString('base64url');
+  }
+  let base64;
+  if (typeof TextEncoder === 'undefined') {
+    base64 = btoa(unescape(encodeURIComponent(json)));
+  } else {
+    const encoder = new TextEncoder();
+    const bytes = encoder.encode(json);
+    let binary = '';
+    bytes.forEach((byte) => {
+      binary += String.fromCharCode(byte);
+    });
+    base64 = btoa(binary);
+  }
+  return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+};
+
+export const decodeShareSnapshot = (encoded) => {
+  if (!encoded) return null;
+  const normalized = encoded.replace(/-/g, '+').replace(/_/g, '/');
+  const padding = normalized.length % 4 === 0 ? '' : '='.repeat(4 - (normalized.length % 4));
+  const base64 = `${normalized}${padding}`;
+  let json;
+  try {
+    if (typeof window === 'undefined' && typeof Buffer !== 'undefined') {
+      json = Buffer.from(base64, 'base64').toString('utf-8');
+    } else {
+      const binary = atob(base64);
+      if (typeof TextDecoder === 'undefined') {
+        json = decodeURIComponent(escape(binary));
+      } else {
+        const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+        const decoder = new TextDecoder();
+        json = decoder.decode(bytes);
+      }
+    }
+    return JSON.parse(json);
+  } catch (error) {
+    console.error('Failed to decode shared snapshot', error);
+    return null;
+  }
+};
+
+export const buildShareUrl = (snapshot) => {
+  if (typeof window === 'undefined') return '';
+  const encoded = encodeShareSnapshot(snapshot);
+  if (!encoded) return '';
+  const url = new URL(window.location.href);
+  url.searchParams.set('share', encoded);
+  return url.toString();
+};
+
+export const clamp01 = (value) => clamp(Number.isFinite(value) ? value : parseFloat(value) || 0, 0, 1);

--- a/docs/mvp-scope.md
+++ b/docs/mvp-scope.md
@@ -18,8 +18,9 @@ The MVP centers on delivering a responsive, browser-based chiptune loop sequence
 - Loop length capped at five minutes regardless of BPM or resolution.
 
 ### Track Management
-- Up to ten simultaneous tracks with per-track mute, solo, and volume controls.
-- Instrument selector offering at least eight chiptune-inspired presets (e.g., pulse lead, triangle bass).
+- Up to ten simultaneous tracks with per-track mute, solo, volume, and expressive shape controls.
+- Instrument selector with classic waveforms plus a custom wave-shaping slider for bespoke timbres.
+- Built-in filter and delay effects per track for quick sound design without leaving the loop view.
 - Track color coding and naming for quick visual parsing.
 
 ### Scale & Harmony Tools
@@ -31,6 +32,7 @@ The MVP centers on delivering a responsive, browser-based chiptune loop sequence
 - Create, duplicate, and delete projects stored locally (IndexedDB) with export/import via JSON.
 - Auto-save on edit events with undo/redo history spanning the last 100 actions.
 - Shareable loop export as `.wav` (offline render) and `.json` (project data).
+- One-click share links that encode the project state for easy remixing and community circulation.
 
 ## Performance Targets
 - Consistent playback without audible jitter between 120–160 BPM on mid-range laptops and tablets.
@@ -39,7 +41,7 @@ The MVP centers on delivering a responsive, browser-based chiptune loop sequence
 
 ## Accessibility & Responsiveness
 - Keyboard navigable interface with focus indicators and ARIA labels on controls.
-- Responsive layout for desktop (≥1280px), tablet (≥768px), and compact laptop displays.
+- Responsive layout for desktop (≥1280px), tablet (≥768px), and a streamlined mobile editing lane (≥480px).
 - High-contrast theme with adjustable font scaling (90%–130%).
 
 ## Out of Scope for MVP


### PR DESCRIPTION
## Summary
- enable shareable URLs with footer UX feedback plus responsive layout tuning for compact screens
- add custom wave shaping alongside per-track filter and delay effects reused in the offline renderer via new sound helpers
- refresh MVP scope documentation to capture sharing and expressive sound design enhancements

## Testing
- npm --prefix bitloops_app test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69100fa314d88326ab01ac7a42850ab6)